### PR TITLE
Use mouse move on non-touch devices

### DIFF
--- a/src/components/Map/MapActionButtons.tsx
+++ b/src/components/Map/MapActionButtons.tsx
@@ -78,7 +78,11 @@ export default function MapActionButtons({ map }: MapActionButtonsOptions) {
       } else {
         if (fzg) {
           console.info(`firecall dialog close for ${fzg.type} ${fzg.name}`);
-          if (NON_DISPLAYABLE_ITEMS.includes(fzg.type)) {
+          if (
+            NON_DISPLAYABLE_ITEMS.includes(fzg.type) ||
+            // on a touch device it is better to drop the marker and move it afterwards
+            navigator.maxTouchPoints > 0
+          ) {
             saveItem({
               ...fzg,
               lat: map.getCenter().lat,


### PR DESCRIPTION
Auf einem Touch device gibt es kein mouse move und somit macht es auch keinen sinn den Marker erst dann zu setzten. In diesem Fall ist es besser, den Marker gleich zu setzten. 