### PR TITLE
Add opentopopmap

### DIFF
--- a/src/components/Map/tiles.ts
+++ b/src/components/Map/tiles.ts
@@ -91,7 +91,7 @@ export const availableLayers: TileConfigs = {
       maxZoom: 19,
       subdomains: ['a', 'b', 'c'],
       attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, SRTM | &copy; <a href="http://opentopomap.org/">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     },
   },
 
@@ -102,7 +102,7 @@ export const availableLayers: TileConfigs = {
       maxZoom: 19,
       subdomains: ['a', 'b', 'c'],
       attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, SRTM | &copy; <a href="http://opentopomap.org/">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
     },
   },
 };

--- a/src/components/Map/tiles.ts
+++ b/src/components/Map/tiles.ts
@@ -91,6 +91,17 @@ export const availableLayers: TileConfigs = {
       maxZoom: 19,
       subdomains: ['a', 'b', 'c'],
       attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, SRTM | &copy; <a href="http://opentopomap.org/">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+    },
+  },
+
+  opentopomap: {
+    name: 'Opentopomap',
+    url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+    options: {
+      maxZoom: 19,
+      subdomains: ['a', 'b', 'c'],
+      attribution:
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     },
   },

--- a/src/worker/patterns.ts
+++ b/src/worker/patterns.ts
@@ -59,6 +59,13 @@ export const cachePatterns: RuntimeCaching[] = [
       plugins: [oneDayCachePlugin],
     }),
   },
+  {
+    matcher: /https:\/\/[a-z].tile.opentopomap.org\/.*/i,
+    handler: new CacheFirst({
+      cacheName: 'opentopomap',
+      plugins: [oneDayCachePlugin],
+    }),
+  },
 
   {
     matcher: /https:\/\/.*.gstatic.com\/.*/i,


### PR DESCRIPTION
Fixes #142 

Basemap bietet leider keine Topokarte an, somit wird in diesem Fall opentopomap.org als Alternative verwendet.