### PR TITLE
Fzg Gruppierung und Verbesserungen für Linien und Kreise

### DIFF
--- a/src/components/FirecallItems/elements/CircleMarker.tsx
+++ b/src/components/FirecallItems/elements/CircleMarker.tsx
@@ -5,6 +5,7 @@ import { Circle as LeafletCircle } from 'react-leaflet';
 import { Circle, FirecallItem } from '../../firebase/firestore';
 import { leafletIcons } from '../icons';
 import { FirecallItemBase } from './FirecallItemBase';
+import { MarkerRenderOptions } from './marker/FirecallItemDefault';
 
 export class CircleMarker extends FirecallItemBase {
   color: string;
@@ -105,10 +106,13 @@ export class CircleMarker extends FirecallItemBase {
     return new CircleMarker();
   }
 
-  public renderMarker(selectItem: (item: FirecallItem) => void) {
+  public renderMarker(
+    selectItem: (item: FirecallItem) => void,
+    { hidePopup = false }: MarkerRenderOptions = {}
+  ) {
     return (
       <>
-        {super.renderMarker(selectItem)}
+        {!hidePopup && super.renderMarker(selectItem)}
         <LeafletCircle
           key={'circle' + this.id}
           color={this.color}
@@ -117,7 +121,7 @@ export class CircleMarker extends FirecallItemBase {
           opacity={this.opacity / 100}
           fill={this.fill === 'true'}
         >
-          {this.renderPopup(selectItem)}
+          {!hidePopup && this.renderPopup(selectItem)}
         </LeafletCircle>
       </>
     );

--- a/src/components/FirecallItems/elements/CircleMarker.tsx
+++ b/src/components/FirecallItems/elements/CircleMarker.tsx
@@ -91,7 +91,7 @@ export class CircleMarker extends FirecallItemBase {
       <>
         <b>Kreis {this.name}</b>
         <br />
-        {this.radius || 0}m
+        {this.radius || 0}m {this.color} {this.fill && '(ausgefüllt)'}
       </>
     );
   }
@@ -115,11 +115,14 @@ export class CircleMarker extends FirecallItemBase {
         {!hidePopup && super.renderMarker(selectItem)}
         <LeafletCircle
           key={'circle' + this.id}
-          color={this.color}
           radius={this.radius}
           center={L.latLng(this.lat, this.lng)}
-          opacity={this.opacity / 100}
-          fill={this.fill === 'true'}
+          pathOptions={{
+            color: this.color,
+            fill: this.fill === 'true',
+            opacity: this.opacity / 100,
+            fillOpacity: this.opacity / 100 / 3,
+          }}
         >
           {!hidePopup && this.renderPopup(selectItem)}
         </LeafletCircle>

--- a/src/components/FirecallItems/elements/FirecallConnection.tsx
+++ b/src/components/FirecallItems/elements/FirecallConnection.tsx
@@ -1,24 +1,17 @@
 import { ReactNode } from 'react';
-import { Icon, IconOptions } from 'leaflet';
-import { defaultPosition } from '../../../hooks/constants';
-import { Connection, FirecallItem } from '../../firebase/firestore';
-import { leafletIcons } from '../icons';
+import { Connection } from '../../firebase/firestore';
 import { FirecallItemBase } from './FirecallItemBase';
-import ConnectionMarker from './connection/ConnectionComponent';
 import { FirecallMultiPoint } from './FirecallMultiPoint';
 
 export class FirecallConnection extends FirecallMultiPoint {
-  destLat: number = defaultPosition.lat;
-  destLng: number = defaultPosition.lng;
-  /** stringified LatLngPosition[] */
-  positions?: string;
-  distance?: number;
-  color?: string;
-  alwaysShowMarker?: string;
+  dimension: string;
+  oneHozeLength: number;
 
   public constructor(firecallItem?: Connection) {
     super(firecallItem);
     this.type = 'connection';
+    this.dimension = firecallItem?.dimension || 'B';
+    this.oneHozeLength = firecallItem?.oneHozeLength || 20;
   }
 
   public copy(): FirecallConnection {
@@ -34,8 +27,45 @@ export class FirecallConnection extends FirecallMultiPoint {
 
   public info(): string {
     return `Länge: ${Math.round(this.distance || 0)}m ${Math.ceil(
-      (this.distance || 0) / 20
-    )} B-Längen`;
+      (this.distance || 0) / this.oneHozeLength
+    )} ${this.dimension}-Längen`;
+  }
+
+  public popupFn(): ReactNode {
+    return (
+      <>
+        <b>
+          {this.markerName()} {this.name}
+        </b>
+        <br />
+        {Math.round(this.distance || 0)}
+        m, {Math.ceil((this.distance || 0) / this.oneHozeLength)}{' '}
+        {this.dimension} Schläuche
+      </>
+    );
+  }
+
+  public data(): Connection {
+    return {
+      ...super.data(),
+      dimension: this.dimension || 'B',
+      oneHozeLength: this.oneHozeLength || 20,
+    } as Connection;
+  }
+
+  public fields(): { [fieldName: string]: string } {
+    return {
+      ...super.fields(),
+      dimension: 'Dimension (B, C etc)',
+      oneHozeLength: 'Länge eines Schlauches (Standard 20m)',
+    };
+  }
+
+  public fieldTypes(): { [fieldName: string]: string } {
+    return {
+      ...super.fieldTypes(),
+      oneHozeLength: 'number',
+    };
   }
 
   public static factory(): FirecallItemBase {

--- a/src/components/FirecallItems/elements/FirecallMultiPoint.tsx
+++ b/src/components/FirecallItems/elements/FirecallMultiPoint.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from 'react';
 import { Icon, IconOptions } from 'leaflet';
+import { ReactNode } from 'react';
 import { defaultPosition } from '../../../hooks/constants';
 import {
   Connection,
@@ -128,8 +128,7 @@ export class FirecallMultiPoint extends FirecallItemBase {
           {this.markerName()} {this.name}
         </b>
         <br />
-        {Math.round(this.distance || 0)}
-        m, {Math.ceil((this.distance || 0) / 20)} B Schläuche
+        {Math.round(this.distance || 0)}m
       </>
     );
   }

--- a/src/components/FirecallItems/elements/connection/ConnectionComponent.tsx
+++ b/src/components/FirecallItems/elements/connection/ConnectionComponent.tsx
@@ -10,7 +10,7 @@ import { LatLngPosition, latLngPosition } from '../../../../common/geo';
 import { defaultPosition } from '../../../../hooks/constants';
 import { useFirecallId } from '../../../../hooks/useFirecall';
 import { Connection, FirecallItem } from '../../../firebase/firestore';
-import { FirecallConnection } from '../FirecallConnection';
+import { FirecallMultiPoint } from '../FirecallMultiPoint';
 import {
   addFirecallPosition,
   deleteFirecallPosition,
@@ -19,7 +19,7 @@ import {
 } from './positions';
 
 export interface ConnectionMarkerProps {
-  record: FirecallConnection;
+  record: FirecallMultiPoint;
   selectItem: (item: FirecallItem) => void;
 }
 

--- a/src/components/firebase/firestore.ts
+++ b/src/components/firebase/firestore.ts
@@ -113,6 +113,8 @@ export interface MultiPointItem extends FirecallItem {
 
 export interface Connection extends MultiPointItem {
   type: 'connection';
+  dimension?: string;
+  oneHozeLength?: number;
 }
 
 export interface Area extends MultiPointItem {

--- a/src/components/pages/FahrzeugePrint.tsx
+++ b/src/components/pages/FahrzeugePrint.tsx
@@ -59,27 +59,46 @@ export default function FahrzeugePrint() {
           </tr>
         </thead>
         <tbody>
-          {vehicles
-            .sort(
-              ({ fw: a = '', name: aa = '' }, { fw: b = '', name: bb = '' }) =>
-                a.localeCompare(b) - aa.localeCompare(bb) / 10
-            )
-            .map((fzg) => (
-              <tr key={fzg.id}>
-                <td>{fzg.fw}</td>
-                <td>{fzg.name}</td>
-                <td>
-                  1:{fzg.besatzung || 0} ({fzg.ats})
-                </td>
-                <td>{fzg.beschreibung}</td>
-                <td>{fzg.alarmierung && formatTimestamp(fzg.alarmierung)}</td>
-                <td>{fzg.eintreffen && formatTimestamp(fzg.eintreffen)}</td>
-                <td>{fzg.abruecken && formatTimestamp(fzg.abruecken)}</td>
-                <td>
-                  {fzg.lat} {fzg.lng}
-                </td>
+          {[
+            {
+              id: undefined,
+              name: 'nicht zugeordnet',
+            },
+            ...Object.values(layers),
+          ].map((layer) => (
+            <React.Fragment key={`fzg-layers-${layer.id}`}>
+              <tr>
+                <th> </th>
+                <th>{layer.name}</th>
               </tr>
-            ))}
+              {vehicles
+                .filter((v) => v.layer === layer.id)
+                .sort(
+                  (
+                    { fw: a = '', name: aa = '' },
+                    { fw: b = '', name: bb = '' }
+                  ) => a.localeCompare(b) - aa.localeCompare(bb) / 10
+                )
+                .map((fzg) => (
+                  <tr key={fzg.id}>
+                    <td>{fzg.fw}</td>
+                    <td>{fzg.name}</td>
+                    <td>
+                      1:{fzg.besatzung || 0} ({fzg.ats})
+                    </td>
+                    <td>{fzg.beschreibung}</td>
+                    <td>
+                      {fzg.alarmierung && formatTimestamp(fzg.alarmierung)}
+                    </td>
+                    <td>{fzg.eintreffen && formatTimestamp(fzg.eintreffen)}</td>
+                    <td>{fzg.abruecken && formatTimestamp(fzg.abruecken)}</td>
+                    <td>
+                      {fzg.lat} {fzg.lng}
+                    </td>
+                  </tr>
+                ))}
+            </React.Fragment>
+          ))}
         </tbody>
       </table>
 


### PR DESCRIPTION
Relates to #220 and #219 

Folgende Punkte werden implementiert / behoben:

- Kreis lässt sich nicht gleich in der Karte ablegen
- Farbe des Kreises Updated sich nicht nach Änderung
- Bei Leitungen eventuelle Auswahl zwischen B und C schaffen
- Kräfte Übersicht nach Layer in der Print ansicht