### PR TITLE
fix: remove overly restrictive Content-Security-Policy header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,51 +15,6 @@ module.exports = async (phase) => {
     // skipWaiting: true,
     transpilePackages: ['mui-color-input'],
     async headers() {
-      // Content-Security-Policy directives
-      const cspDirectives = [
-        // Default: only same origin
-        "default-src 'self'",
-        // Scripts: self + inline for Next.js hydration (nonce would be better but requires custom server)
-        "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-        // Styles: self + unsafe-inline required by MUI (emotion/styled-components)
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-        // Images: self + data URIs (Leaflet markers) + any https (tile servers, Firebase Storage, Google profile pics, user-defined icons)
-        "img-src 'self' data: blob: https:",
-        // Fonts: self + Google Fonts
-        "font-src 'self' https://fonts.gstatic.com",
-        // Connect: API calls to Firebase, Google APIs, tile servers, etc.
-        [
-          "connect-src 'self'",
-          'https://*.googleapis.com',
-          'https://*.firebaseio.com',
-          'https://*.firebaseapp.com',
-          'wss://*.firebaseio.com',
-          'https://firebasestorage.googleapis.com',
-          'https://*.tile.openstreetmap.org',
-          'https://*.tile.opentopomap.org',
-          'https://mapsneu.wien.gv.at',
-          'https://tiles.lfrz.gv.at',
-          'https://gisenterprise.bgld.gv.at',
-          'https://unpkg.com',
-          'https://nominatim.openstreetmap.org',
-        ].join(' '),
-        // Frames: none (we don't embed iframes)
-        "frame-src 'self'",
-        // Workers: self for service worker
-        "worker-src 'self'",
-        // Media: self for audio recording (AI assistant)
-        "media-src 'self' blob: data:",
-        // Object/base: none
-        "object-src 'none'",
-        "base-uri 'self'",
-        // Form submissions
-        "form-action 'self'",
-        // Manifest for PWA
-        "manifest-src 'self'",
-      ];
-
-      const csp = cspDirectives.join('; ');
-
       return [
         {
           source: '/(.*)',
@@ -79,10 +34,6 @@ module.exports = async (phase) => {
             {
               key: 'Referrer-Policy',
               value: 'strict-origin-when-cross-origin',
-            },
-            {
-              key: 'Content-Security-Policy',
-              value: csp,
             },
           ],
         },


### PR DESCRIPTION
## Zusammenfassung

Die Content-Security-Policy war zu restriktiv und hat wichtige externe Ressourcen blockiert, was zu Fehlern beim Login und bei der App-Initialisierung geführt hat.

## Änderungen

- CSP-Header aus `next.config.js` entfernt
- Andere Security-Header (X-Frame-Options, HSTS, X-Content-Type-Options, Referrer-Policy) bleiben erhalten

## Test plan

- [ ] App aufrufen und prüfen, dass keine CSP-Fehler in der Browser-Console erscheinen
- [ ] Google Login funktioniert (reCAPTCHA und Auth UI Assets laden)
- [ ] Google Analytics/Tag Manager wird geladen
- [ ] Firestore-Verbindung funktioniert ohne `auth/network-request-failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)