### PR TITLE
feat(chrome-extension): automatic CWS publish and overview enhancements

### DIFF
--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -253,14 +253,13 @@ jobs:
           CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
           CWS_EXTENSION_ID: ${{ vars.CWS_EXTENSION_ID }}
-          CRX_FILE: ${{ steps.version.outputs.CRX_FILE }}
         run: |
           set -eo pipefail
           if [[ -z "${CWS_CLIENT_ID}" || -z "${CWS_CLIENT_SECRET}" || -z "${CWS_REFRESH_TOKEN}" || -z "${CWS_EXTENSION_ID}" ]]; then
             echo "::notice::Chrome Web Store publish skipped — CWS_CLIENT_ID, CWS_CLIENT_SECRET, CWS_REFRESH_TOKEN, or CWS_EXTENSION_ID not configured"
             exit 0
           fi
-          npx chrome-webstore-upload-cli@3 upload --source "${CRX_FILE}" --auto-publish
+          node scripts/publish-cws.mjs
 
       - name: Cleanup private key and env
         if: always()

--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -245,6 +245,23 @@ jobs:
           upload_file "${CRX_FILE}" "application/x-chrome-extension"
           upload_file "${ZIP_FILE}" "application/zip"
 
+      - name: Publish to Chrome Web Store
+        if: github.event_name == 'release'
+        working-directory: chrome-extension
+        env:
+          CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+          CWS_EXTENSION_ID: ${{ vars.CWS_EXTENSION_ID }}
+          ZIP_FILE: ${{ steps.version.outputs.ZIP_FILE }}
+        run: |
+          set -eo pipefail
+          if [[ -z "${CWS_CLIENT_ID}" || -z "${CWS_CLIENT_SECRET}" || -z "${CWS_REFRESH_TOKEN}" || -z "${CWS_EXTENSION_ID}" ]]; then
+            echo "::notice::Chrome Web Store publish skipped — CWS_CLIENT_ID, CWS_CLIENT_SECRET, CWS_REFRESH_TOKEN, or CWS_EXTENSION_ID not configured"
+            exit 0
+          fi
+          npx chrome-webstore-upload-cli@3 upload --source "${ZIP_FILE}" --auto-publish
+
       - name: Cleanup private key and env
         if: always()
         run: |

--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -253,14 +253,14 @@ jobs:
           CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
           CWS_EXTENSION_ID: ${{ vars.CWS_EXTENSION_ID }}
-          ZIP_FILE: ${{ steps.version.outputs.ZIP_FILE }}
+          CRX_FILE: ${{ steps.version.outputs.CRX_FILE }}
         run: |
           set -eo pipefail
           if [[ -z "${CWS_CLIENT_ID}" || -z "${CWS_CLIENT_SECRET}" || -z "${CWS_REFRESH_TOKEN}" || -z "${CWS_EXTENSION_ID}" ]]; then
             echo "::notice::Chrome Web Store publish skipped — CWS_CLIENT_ID, CWS_CLIENT_SECRET, CWS_REFRESH_TOKEN, or CWS_EXTENSION_ID not configured"
             exit 0
           fi
-          npx chrome-webstore-upload-cli@3 upload --source "${ZIP_FILE}" --auto-publish
+          npx chrome-webstore-upload-cli@3 upload --source "${CRX_FILE}" --auto-publish
 
       - name: Cleanup private key and env
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.envrc
 
 # vercel
 .vercel

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -85,6 +85,39 @@ openssl pkey -in dist.pem -pubout -outform DER | base64
 Policy verwenden. Für manuelle Tests das ZIP entpacken und als „Entpackte
 Erweiterung" laden.
 
+### Publish to Chrome Web Store
+
+Zum Veröffentlichen im Chrome Web Store werden OAuth2-Credentials benötigt.
+
+#### Einmalig: Refresh Token generieren
+
+1. In der Google Cloud Console unter *APIs & Services > Credentials* einen
+   OAuth 2.0 Client (Typ: **Desktop app**) erstellen (oder den bestehenden verwenden)
+1. Die Chrome Web Store API im Projekt aktivieren
+1. `CWS_CLIENT_ID` und `CWS_CLIENT_SECRET` in der `.envrc` im Projekt-Root eintragen
+1. Refresh Token interaktiv generieren:
+
+```bash
+direnv exec . npx chrome-webstore-upload-keys@latest
+```
+
+1. Den ausgegebenen Refresh Token als `CWS_REFRESH_TOKEN` in die `.envrc` eintragen
+
+#### Publish ausführen
+
+Folgende Umgebungsvariablen müssen in der `.envrc` gesetzt sein:
+
+- `CWS_CLIENT_ID` — Google OAuth2 Client ID
+- `CWS_CLIENT_SECRET` — Google OAuth2 Client Secret
+- `CWS_REFRESH_TOKEN` — OAuth2 Refresh Token
+- `CWS_EXTENSION_ID` — Chrome Web Store Extension ID
+
+```bash
+npm run publish:cws
+```
+
+Baut die Extension und veröffentlicht sie im Chrome Web Store.
+
 ### In Chrome laden
 
 1. `chrome://extensions/` öffnen

--- a/chrome-extension/manifest.config.ts
+++ b/chrome-extension/manifest.config.ts
@@ -88,16 +88,11 @@ export default defineManifest(async (env) => {
   // Base64-kodierter DER Public Key, abgeleitet aus dem privaten Schluessel
   // in chrome-extension/dist.pem (*.pem ist .gitignored).
   //
-  // Das `key`-Feld fixiert die Extension-ID nur bei Unpacked-Loads im
-  // Dev-Modus. Bei Production-Builds (EXT_ENV_LOCAL=1) wird es weggelassen:
-  //   - Der Chrome Web Store lehnt ZIP-Uploads mit `key` ab
-  //     ("Das Feld 'key' ist im Manifest nicht zulaessig").
-  //   - Die CRX wird mit dist.pem signiert; Chrome leitet die Extension-ID
-  //     automatisch aus dem in der CRX eingebetteten Public Key ab,
-  //     sodass die ID auch ohne `key` im Manifest stabil bleibt.
-  const extensionPublicKey = process.env.EXT_ENV_LOCAL
-    ? undefined
-    : viteEnv.CHROME_EXTENSION_PUBLIC_KEY;
+  // Das `key`-Feld fixiert die Extension-ID sowohl bei Unpacked-Loads als
+  // auch bei lokalen Prod-Builds (dist/ direkt laden). Der Chrome Web Store
+  // lehnt ZIP-Uploads mit `key` ab — daher entfernt package.mjs das Feld
+  // nur aus der ZIP-Datei, nicht aus dist/manifest.json.
+  const extensionPublicKey = viteEnv.CHROME_EXTENSION_PUBLIC_KEY;
 
   return {
     manifest_version: 3,

--- a/chrome-extension/package-lock.json
+++ b/chrome-extension/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
         "@vitejs/plugin-react": "^4.4.1",
+        "chrome-webstore-upload": "^4.0.3",
         "crx3": "^2.0.0",
         "jsdom": "^29.0.2",
         "typescript": "^5.8.3",
@@ -3075,6 +3076,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/chrome-webstore-upload": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-webstore-upload/-/chrome-webstore-upload-4.0.3.tgz",
+      "integrity": "sha512-sEMUf65BkkVygtVcMoJ/EoshcIsoJvLVUm9vrKI+RkLeMcraTyiP08Md5kAvlVhRKIoZk6pXzyi6WNQkcLRRWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "junk": "^4.0.1",
+        "yazl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3873,6 +3891,19 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/junk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lines-and-columns": {

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -9,8 +9,7 @@
     "build:prod": "tsc --noEmit && EXT_ENV_LOCAL=1 vite build && node scripts/package.mjs",
     "preview": "vite preview",
     "test": "vitest run",
-    "publish:cws": "npm run build:prod && node scripts/publish-cws.mjs",
-    "cws:login": "npx chrome-webstore-upload-cli@3 init --client-id=$CWS_CLIENT_ID --client-secret=$CWS_CLIENT_SECRET"
+    "publish:cws": "npm run build:prod && node scripts/publish-cws.mjs"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -9,7 +9,8 @@
     "build:prod": "tsc --noEmit && EXT_ENV_LOCAL=1 vite build && node scripts/package.mjs",
     "preview": "vite preview",
     "test": "vitest run",
-    "publish:cws": "npm run build:prod && node scripts/publish-cws.mjs"
+    "publish:cws": "npm run build:prod && node scripts/publish-cws.mjs",
+    "cws:login": "npx chrome-webstore-upload-keys@latest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -8,7 +8,9 @@
     "build": "tsc --noEmit && vite build",
     "build:prod": "tsc --noEmit && EXT_ENV_LOCAL=1 vite build && node scripts/package.mjs",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "publish:cws": "npm run build:prod && node scripts/publish-cws.mjs",
+    "cws:login": "npx chrome-webstore-upload-cli@3 init --client-id=$CWS_CLIENT_ID --client-secret=$CWS_CLIENT_SECRET"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -25,6 +27,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react": "^4.4.1",
+    "chrome-webstore-upload": "^4.0.3",
     "crx3": "^2.0.0",
     "jsdom": "^29.0.2",
     "typescript": "^5.8.3",

--- a/chrome-extension/scripts/package.mjs
+++ b/chrome-extension/scripts/package.mjs
@@ -11,7 +11,13 @@
 //   - <OUTPUT_BASE>.crx   signed extension for Enterprise/Self-Hosting
 
 import crx3 from 'crx3';
-import { readFileSync, readdirSync, existsSync, unlinkSync } from 'node:fs';
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  existsSync,
+  unlinkSync,
+} from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -54,11 +60,26 @@ for (const file of readdirSync(extRoot)) {
   }
 }
 
-await crx3([manifestPath], {
-  keyPath,
-  crxPath,
-  zipPath,
-});
+// Der Chrome Web Store lehnt ZIP-Uploads mit `key` im Manifest ab. Das Feld
+// wird daher vor dem Packaging entfernt und danach in dist/manifest.json
+// wiederhergestellt, damit die Extension auch direkt aus dist/ als unpacked
+// mit stabiler ID geladen werden kann.
+const originalManifest = readFileSync(manifestPath, 'utf8');
+if (manifest.key) {
+  const { key: _key, ...manifestWithoutKey } = manifest;
+  writeFileSync(manifestPath, JSON.stringify(manifestWithoutKey, null, 2));
+}
+
+try {
+  await crx3([manifestPath], {
+    keyPath,
+    crxPath,
+    zipPath,
+  });
+} finally {
+  // Immer wiederherstellen, auch bei Fehler
+  writeFileSync(manifestPath, originalManifest);
+}
 
 console.log(`\u2713 ${zipPath}  \u2192 Upload zu Chrome Web Store`);
 console.log(`\u2713 ${crxPath}  \u2192 Enterprise Policy / Self-Hosting`);

--- a/chrome-extension/scripts/publish-cws.mjs
+++ b/chrome-extension/scripts/publish-cws.mjs
@@ -9,7 +9,7 @@
 // Run `npm run build:prod` before this script to generate the ZIP.
 
 import chromeWebstoreUpload from 'chrome-webstore-upload';
-import { createReadStream, readdirSync } from 'node:fs';
+import { readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -32,24 +32,24 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
-// --- Find the latest ZIP artifact ---
-const zipPattern = /^einsatzkarte-.*\.zip$/;
-const zips = readdirSync(extRoot).filter((f) => zipPattern.test(f));
-if (zips.length === 0) {
+// --- Find the latest CRX artifact ---
+const crxPattern = /^einsatzkarte-.*\.crx$/;
+const crxFiles = readdirSync(extRoot).filter((f) => crxPattern.test(f));
+if (crxFiles.length === 0) {
   console.error(
-    'Error: no einsatzkarte-*.zip found. Run `npm run build:prod` first.',
+    'Error: no einsatzkarte-*.crx found. Run `npm run build:prod` first.',
   );
   process.exit(1);
 }
-if (zips.length > 1) {
+if (crxFiles.length > 1) {
   console.error(
-    `Error: found multiple ZIP files: ${zips.join(', ')}. ` +
+    `Error: found multiple CRX files: ${crxFiles.join(', ')}. ` +
       'Expected exactly one (build:prod cleans old artifacts).',
   );
   process.exit(1);
 }
-const zipPath = resolve(extRoot, zips[0]);
-console.log(`Publishing ${zips[0]} to Chrome Web Store...`);
+const crxPath = resolve(extRoot, crxFiles[0]);
+console.log(`Publishing ${crxFiles[0]} to Chrome Web Store...`);
 
 // --- Upload and publish ---
 const store = chromeWebstoreUpload({
@@ -59,8 +59,7 @@ const store = chromeWebstoreUpload({
   refreshToken: process.env.CWS_REFRESH_TOKEN,
 });
 
-const zipStream = createReadStream(zipPath);
-const uploadResult = await store.uploadExisting(zipStream);
+const uploadResult = await store.uploadExisting(crxPath);
 
 if (uploadResult.uploadState === 'FAILURE') {
   console.error('Upload failed:', JSON.stringify(uploadResult, null, 2));

--- a/chrome-extension/scripts/publish-cws.mjs
+++ b/chrome-extension/scripts/publish-cws.mjs
@@ -1,0 +1,77 @@
+// Publishes the latest einsatzkarte-*.zip to the Chrome Web Store.
+//
+// Required environment variables:
+//   CWS_CLIENT_ID        — Google OAuth2 client ID
+//   CWS_CLIENT_SECRET    — Google OAuth2 client secret
+//   CWS_REFRESH_TOKEN    — OAuth2 refresh token
+//   CWS_EXTENSION_ID     — Chrome Web Store extension ID
+//
+// Run `npm run build:prod` before this script to generate the ZIP.
+
+import chromeWebstoreUpload from 'chrome-webstore-upload';
+import { createReadStream, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const extRoot = resolve(__dirname, '..');
+
+// --- Validate environment variables ---
+const required = [
+  'CWS_CLIENT_ID',
+  'CWS_CLIENT_SECRET',
+  'CWS_REFRESH_TOKEN',
+  'CWS_EXTENSION_ID',
+];
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length > 0) {
+  console.error(
+    `Error: missing environment variables: ${missing.join(', ')}\n` +
+      'Set them before running this script.',
+  );
+  process.exit(1);
+}
+
+// --- Find the latest ZIP artifact ---
+const zipPattern = /^einsatzkarte-.*\.zip$/;
+const zips = readdirSync(extRoot).filter((f) => zipPattern.test(f));
+if (zips.length === 0) {
+  console.error(
+    'Error: no einsatzkarte-*.zip found. Run `npm run build:prod` first.',
+  );
+  process.exit(1);
+}
+if (zips.length > 1) {
+  console.error(
+    `Error: found multiple ZIP files: ${zips.join(', ')}. ` +
+      'Expected exactly one (build:prod cleans old artifacts).',
+  );
+  process.exit(1);
+}
+const zipPath = resolve(extRoot, zips[0]);
+console.log(`Publishing ${zips[0]} to Chrome Web Store...`);
+
+// --- Upload and publish ---
+const store = chromeWebstoreUpload({
+  extensionId: process.env.CWS_EXTENSION_ID,
+  clientId: process.env.CWS_CLIENT_ID,
+  clientSecret: process.env.CWS_CLIENT_SECRET,
+  refreshToken: process.env.CWS_REFRESH_TOKEN,
+});
+
+const zipStream = createReadStream(zipPath);
+const uploadResult = await store.uploadExisting(zipStream);
+
+if (uploadResult.uploadState === 'FAILURE') {
+  console.error('Upload failed:', JSON.stringify(uploadResult, null, 2));
+  process.exit(1);
+}
+console.log('Upload successful:', uploadResult.uploadState);
+
+const publishResult = await store.publish();
+if (publishResult.status.includes('OK')) {
+  console.log('Published successfully!');
+} else {
+  console.error('Publish failed:', JSON.stringify(publishResult, null, 2));
+  process.exit(1);
+}

--- a/chrome-extension/scripts/publish-cws.mjs
+++ b/chrome-extension/scripts/publish-cws.mjs
@@ -1,4 +1,4 @@
-// Publishes the latest einsatzkarte-*.zip to the Chrome Web Store.
+// Publishes the latest einsatzkarte-*.crx to the Chrome Web Store.
 //
 // Required environment variables:
 //   CWS_CLIENT_ID        — Google OAuth2 client ID
@@ -6,7 +6,7 @@
 //   CWS_REFRESH_TOKEN    — OAuth2 refresh token
 //   CWS_EXTENSION_ID     — Chrome Web Store extension ID
 //
-// Run `npm run build:prod` before this script to generate the ZIP.
+// Run `npm run build:prod` before this script to generate the CRX.
 
 import chromeWebstoreUpload from 'chrome-webstore-upload';
 import { readdirSync } from 'node:fs';

--- a/chrome-extension/src/popup/App.tsx
+++ b/chrome-extension/src/popup/App.tsx
@@ -19,6 +19,7 @@ import DiaryForm from './components/DiaryForm';
 import { useFirecalls } from './hooks/useFirecalls';
 import { useFirecallItems } from './hooks/useFirecallItems';
 import { useDiaries } from './hooks/useDiaries';
+import { useCrewAssignments } from './hooks/useCrewAssignments';
 import { useUserClaims } from './hooks/useUserClaims';
 
 
@@ -31,6 +32,7 @@ function MainContent({ email }: { email: string }) {
   const [tab, setTab] = useState(0);
   const [showForm, setShowForm] = useState(false);
   const { items, loading: itemsLoading } = useFirecallItems(selectedFirecallId);
+  const { crew, loading: crewLoading } = useCrewAssignments(selectedFirecallId);
   const { diaries, loading: diariesLoading } = useDiaries(selectedFirecallId);
 
   const selectedFirecall = firecalls.find(
@@ -87,8 +89,10 @@ function MainContent({ email }: { email: string }) {
       {tab === 0 && (
         <FirecallOverview
           firecall={selectedFirecall}
+          firecallId={selectedFirecallId}
           items={items}
-          loading={itemsLoading}
+          crew={crew}
+          loading={itemsLoading || crewLoading}
         />
       )}
       {tab === 1 && (

--- a/chrome-extension/src/popup/App.tsx
+++ b/chrome-extension/src/popup/App.tsx
@@ -46,10 +46,15 @@ function MainContent({ email }: { email: string }) {
     });
   }, []);
 
-  // Auto-select most recent firecall if nothing persisted.
+  // Auto-select most recent firecall if nothing persisted or the persisted
+  // selection no longer exists in the current database (e.g. after switching
+  // from dev to prod).
   // setState during render is the React 19 pattern for deriving state from
   // changing props — avoids the set-state-in-effect lint rule.
-  if (firecalls.length > 0 && !selectedFirecallId) {
+  if (
+    firecalls.length > 0 &&
+    (!selectedFirecallId || !firecalls.some((fc) => fc.id === selectedFirecallId))
+  ) {
     setSelectedFirecallId(firecalls[0].id!);
   }
 

--- a/chrome-extension/src/popup/components/FirecallOverview.tsx
+++ b/chrome-extension/src/popup/components/FirecallOverview.tsx
@@ -1,34 +1,95 @@
-import { Box, Typography, Chip, Skeleton, Divider } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Chip,
+  Skeleton,
+  Divider,
+  Link,
+  List,
+  ListItem,
+  ListSubheader,
+} from '@mui/material';
 import LocalFireDepartment from '@mui/icons-material/LocalFireDepartment';
 import DirectionsCar from '@mui/icons-material/DirectionsCar';
+import People from '@mui/icons-material/People';
 import AccessTime from '@mui/icons-material/AccessTime';
-import { Firecall, FirecallItem } from '@shared/types';
+import {
+  Firecall,
+  FirecallItem,
+  CrewAssignment,
+  funktionAbkuerzung,
+} from '@shared/types';
+import { EINSATZKARTE_URL } from '@shared/config';
 
 interface FirecallOverviewProps {
   firecall: Firecall | undefined;
+  firecallId: string | null;
   items: FirecallItem[];
+  crew: CrewAssignment[];
   loading: boolean;
+}
+
+interface Fzg extends FirecallItem {
+  fw?: string;
+  besatzung?: string;
+  type: 'vehicle';
 }
 
 export default function FirecallOverview({
   firecall,
+  firecallId,
   items,
+  crew,
   loading,
 }: FirecallOverviewProps) {
   if (loading || !firecall) {
     return <Skeleton variant="rectangular" height={200} />;
   }
 
-  const vehicleCount = items.filter((i) => i.type === 'vehicle').length;
+  const vehicles = items.filter((i): i is Fzg => i.type === 'vehicle');
   const isActive = !!firecall.eintreffen && !firecall.abruecken;
+
+  const crewByVehicle = new Map<string | null, CrewAssignment[]>();
+  for (const member of crew) {
+    const key = member.vehicleId;
+    const list = crewByVehicle.get(key) ?? [];
+    list.push(member);
+    crewByVehicle.set(key, list);
+  }
+
+  const unassignedCrew = crewByVehicle.get(null) ?? [];
+
+  const detailUrl = firecallId
+    ? `${EINSATZKARTE_URL}/einsatz/${firecallId}/details`
+    : undefined;
+
+  const handleTitleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (detailUrl) {
+      chrome.tabs.create({ url: detailUrl });
+    }
+  };
 
   return (
     <Box sx={{ p: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <LocalFireDepartment color="error" />
-        <Typography variant="h6" sx={{ flex: 1 }}>
-          {firecall.name}
-        </Typography>
+        {detailUrl ? (
+          <Link
+            href={detailUrl}
+            onClick={handleTitleClick}
+            underline="hover"
+            color="inherit"
+            variant="h6"
+            sx={{ flex: 1, cursor: 'pointer' }}
+          >
+            {firecall.name}
+          </Link>
+        ) : (
+          <Typography variant="h6" sx={{ flex: 1 }}>
+            {firecall.name}
+          </Typography>
+        )}
         <Chip
           label={isActive ? 'Aktiv' : 'Beendet'}
           color={isActive ? 'error' : 'default'}
@@ -56,10 +117,92 @@ export default function FirecallOverview({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <DirectionsCar fontSize="small" color="action" />
           <Typography variant="body2">
-            {vehicleCount} Fahrzeug{vehicleCount !== 1 ? 'e' : ''}
+            {vehicles.length} Fahrzeug{vehicles.length !== 1 ? 'e' : ''}
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <People fontSize="small" color="action" />
+          <Typography variant="body2">
+            {crew.length} Person{crew.length !== 1 ? 'en' : ''}
           </Typography>
         </Box>
       </Box>
+
+      {(vehicles.length > 0 || crew.length > 0) && (
+        <>
+          <Divider />
+          <List dense disablePadding>
+            {vehicles.map((vehicle) => {
+              const vehicleCrew = crewByVehicle.get(vehicle.id!) ?? [];
+              return (
+                <Box key={vehicle.id}>
+                  <ListSubheader
+                    disableSticky
+                    sx={{ lineHeight: '32px', px: 1 }}
+                  >
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                    >
+                      <DirectionsCar fontSize="small" />
+                      <strong>{vehicle.name}</strong>
+                      {vehicle.fw && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          component="span"
+                        >
+                          ({vehicle.fw})
+                        </Typography>
+                      )}
+                    </Box>
+                  </ListSubheader>
+                  {vehicleCrew.length > 0 ? (
+                    vehicleCrew.map((member) => (
+                      <ListItem key={member.id} sx={{ py: 0, pl: 4 }}>
+                        <Typography variant="body2">
+                          {funktionAbkuerzung(member.funktion)}: {member.name}
+                        </Typography>
+                      </ListItem>
+                    ))
+                  ) : (
+                    <ListItem sx={{ py: 0, pl: 4 }}>
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ fontStyle: 'italic' }}
+                      >
+                        Keine Mannschaft zugeordnet
+                      </Typography>
+                    </ListItem>
+                  )}
+                </Box>
+              );
+            })}
+            {unassignedCrew.length > 0 && (
+              <Box>
+                <ListSubheader
+                  disableSticky
+                  sx={{ lineHeight: '32px', px: 1 }}
+                >
+                  <Box
+                    sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                  >
+                    <People fontSize="small" />
+                    <strong>Ohne Fahrzeug</strong>
+                  </Box>
+                </ListSubheader>
+                {unassignedCrew.map((member) => (
+                  <ListItem key={member.id} sx={{ py: 0, pl: 4 }}>
+                    <Typography variant="body2">
+                      {funktionAbkuerzung(member.funktion)}: {member.name}
+                    </Typography>
+                  </ListItem>
+                ))}
+              </Box>
+            )}
+          </List>
+        </>
+      )}
     </Box>
   );
 }

--- a/chrome-extension/src/popup/hooks/useCrewAssignments.ts
+++ b/chrome-extension/src/popup/hooks/useCrewAssignments.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { collection, query, onSnapshot } from 'firebase/firestore';
+import { firestore } from '@shared/firebase';
+import {
+  CrewAssignment,
+  FIRECALL_COLLECTION_ID,
+  FIRECALL_CREW_COLLECTION_ID,
+} from '@shared/types';
+
+export function useCrewAssignments(firecallId: string | null) {
+  const [crew, setCrew] = useState<CrewAssignment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!firecallId) return;
+
+    const q = query(
+      collection(
+        firestore,
+        FIRECALL_COLLECTION_ID,
+        firecallId,
+        FIRECALL_CREW_COLLECTION_ID
+      )
+    );
+
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const assignments = snapshot.docs.map(
+          (doc) => ({ ...doc.data(), id: doc.id }) as CrewAssignment
+        );
+        setCrew(assignments);
+        setLoading(false);
+      },
+      (error) => {
+        console.error('CrewAssignments subscription error:', error);
+        setCrew([]);
+        setLoading(false);
+      }
+    );
+
+    return unsubscribe;
+  }, [firecallId]);
+
+  if (!firecallId) {
+    return { crew: [] as CrewAssignment[], loading: false };
+  }
+  return { crew, loading };
+}

--- a/chrome-extension/src/shared/types.ts
+++ b/chrome-extension/src/shared/types.ts
@@ -4,10 +4,15 @@ export type {
   Firecall,
   FirecallItem,
   Diary,
+  CrewAssignment,
 } from '../../../src/components/firebase/firestore';
 
 // Re-export collection constants
 export {
   FIRECALL_COLLECTION_ID,
   FIRECALL_ITEMS_COLLECTION_ID,
+  FIRECALL_CREW_COLLECTION_ID,
 } from '../../../src/components/firebase/firestore';
+
+// Re-export helper functions
+export { funktionAbkuerzung } from '../../../src/components/firebase/firestore';

--- a/chrome-extension/vite.config.ts
+++ b/chrome-extension/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
     },
   },
   build: {
+    chunkSizeWarningLimit: 600,
     rollupOptions: {
       input: {
         popup: resolve(__dirname, 'src/popup/index.html'),

--- a/docs/plans/2026-04-16-cws-publish-script-design.md
+++ b/docs/plans/2026-04-16-cws-publish-script-design.md
@@ -1,0 +1,209 @@
+# CWS Publish Script Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a local `npm run publish:cws` script that builds the Chrome extension and publishes it to the Chrome Web Store.
+
+**Architecture:** A Node.js script (`scripts/publish-cws.mjs`) that reads CWS credentials from environment variables, finds the latest build artifact ZIP, and uses the `chrome-webstore-upload` library to upload + auto-publish. Wired up as `npm run publish:cws` which runs `build:prod` first.
+
+**Tech Stack:** Node.js ESM, `chrome-webstore-upload` npm package
+
+---
+
+### Task 1: Install `chrome-webstore-upload` dependency
+
+**Files:**
+- Modify: `chrome-extension/package.json` (devDependencies)
+
+**Step 1: Install the package**
+
+Run (from `chrome-extension/`):
+```bash
+npm install --save-dev chrome-webstore-upload
+```
+
+**Step 2: Verify installation**
+
+Run:
+```bash
+node -e "import('chrome-webstore-upload').then(m => console.log('OK', typeof m.default))"
+```
+Expected: `OK function`
+
+**Step 3: Commit**
+
+```bash
+git add chrome-extension/package.json chrome-extension/package-lock.json
+git commit -m "chore(chrome-extension): add chrome-webstore-upload dependency"
+```
+
+---
+
+### Task 2: Create `scripts/publish-cws.mjs`
+
+**Files:**
+- Create: `chrome-extension/scripts/publish-cws.mjs`
+
+**Step 1: Write the publish script**
+
+```js
+// Publishes the latest einsatzkarte-*.zip to the Chrome Web Store.
+//
+// Required environment variables:
+//   CWS_CLIENT_ID        — Google OAuth2 client ID
+//   CWS_CLIENT_SECRET    — Google OAuth2 client secret
+//   CWS_REFRESH_TOKEN    — OAuth2 refresh token
+//   CWS_EXTENSION_ID     — Chrome Web Store extension ID
+//
+// Run `npm run build:prod` before this script to generate the ZIP.
+
+import chromeWebstoreUpload from 'chrome-webstore-upload';
+import { createReadStream, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const extRoot = resolve(__dirname, '..');
+
+// --- Validate environment variables ---
+const required = [
+  'CWS_CLIENT_ID',
+  'CWS_CLIENT_SECRET',
+  'CWS_REFRESH_TOKEN',
+  'CWS_EXTENSION_ID',
+];
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length > 0) {
+  console.error(
+    `Error: missing environment variables: ${missing.join(', ')}\n` +
+      'Set them before running this script.',
+  );
+  process.exit(1);
+}
+
+// --- Find the latest ZIP artifact ---
+const zipPattern = /^einsatzkarte-.*\.zip$/;
+const zips = readdirSync(extRoot).filter((f) => zipPattern.test(f));
+if (zips.length === 0) {
+  console.error(
+    'Error: no einsatzkarte-*.zip found. Run `npm run build:prod` first.',
+  );
+  process.exit(1);
+}
+if (zips.length > 1) {
+  console.error(
+    `Error: found multiple ZIP files: ${zips.join(', ')}. ` +
+      'Expected exactly one (build:prod cleans old artifacts).',
+  );
+  process.exit(1);
+}
+const zipPath = resolve(extRoot, zips[0]);
+console.log(`Publishing ${zips[0]} to Chrome Web Store...`);
+
+// --- Upload and publish ---
+const store = chromeWebstoreUpload({
+  extensionId: process.env.CWS_EXTENSION_ID,
+  clientId: process.env.CWS_CLIENT_ID,
+  clientSecret: process.env.CWS_CLIENT_SECRET,
+  refreshToken: process.env.CWS_REFRESH_TOKEN,
+});
+
+const zipStream = createReadStream(zipPath);
+const uploadResult = await store.uploadExisting(zipStream);
+
+if (uploadResult.uploadState === 'FAILURE') {
+  console.error('Upload failed:', JSON.stringify(uploadResult, null, 2));
+  process.exit(1);
+}
+console.log('Upload successful:', uploadResult.uploadState);
+
+const publishResult = await store.publish();
+if (publishResult.status.includes('OK')) {
+  console.log('Published successfully!');
+} else {
+  console.error('Publish failed:', JSON.stringify(publishResult, null, 2));
+  process.exit(1);
+}
+```
+
+**Step 2: Test that the script validates env vars**
+
+Run:
+```bash
+cd chrome-extension && node scripts/publish-cws.mjs
+```
+Expected: Error message listing all 4 missing env vars, exit code 1.
+
+**Step 3: Commit**
+
+```bash
+git add chrome-extension/scripts/publish-cws.mjs
+git commit -m "feat(chrome-extension): add CWS publish script"
+```
+
+---
+
+### Task 3: Add `publish:cws` npm script
+
+**Files:**
+- Modify: `chrome-extension/package.json` (scripts section)
+
+**Step 1: Add the script**
+
+Add to `scripts` in `chrome-extension/package.json`:
+```json
+"publish:cws": "npm run build:prod && node scripts/publish-cws.mjs"
+```
+
+**Step 2: Verify dry-run (without CWS credentials)**
+
+Run:
+```bash
+cd chrome-extension && npm run publish:cws
+```
+Expected: Build succeeds, then script exits with error about missing CWS env vars.
+
+**Step 3: Commit**
+
+```bash
+git add chrome-extension/package.json
+git commit -m "feat(chrome-extension): add npm run publish:cws script"
+```
+
+---
+
+### Task 4: Update README with publish instructions
+
+**Files:**
+- Modify: `chrome-extension/README.md`
+
+**Step 1: Add publish section**
+
+Add after the existing "Release Build" section:
+
+```markdown
+### Publish to Chrome Web Store
+
+Set the following environment variables:
+
+- `CWS_CLIENT_ID` — Google OAuth2 client ID (Chrome Web Store API)
+- `CWS_CLIENT_SECRET` — Google OAuth2 client secret
+- `CWS_REFRESH_TOKEN` — OAuth2 refresh token
+- `CWS_EXTENSION_ID` — Chrome Web Store extension ID
+
+Then run:
+
+```bash
+npm run publish:cws
+```
+
+This runs a full production build and publishes the extension to the Chrome Web Store.
+
+To generate the credentials, see [Chrome Web Store API docs](https://developer.chrome.com/docs/webstore/using-api).
+
+**Step 2: Commit**
+
+```bash
+git add chrome-extension/README.md
+git commit -m "docs(chrome-extension): add CWS publish instructions to README"
+```

--- a/docs/plans/2026-04-16-extension-overview-vehicles-crew-design.md
+++ b/docs/plans/2026-04-16-extension-overview-vehicles-crew-design.md
@@ -1,0 +1,50 @@
+# Chrome Extension: Fahrzeuge & Mannschaft in Übersicht
+
+## Zusammenfassung
+
+Die Übersichtsseite (Popup) der Chrome Extension zeigt aktuell nur den Einsatz-Namen, Status, Beschreibung, Datum und eine Fahrzeug-Anzahl. Ziel ist es, Fahrzeuge mit zugeordneter Mannschaft gruppiert darzustellen und den Einsatz-Titel als Link zur Detailseite der Hauptapp zu machen.
+
+## Design
+
+### 1. Einsatz-Titel als Link
+
+Der Firecall-Name wird ein klickbarer Link, der `chrome.tabs.create` nutzt um `https://einsatz.ffnd.at/einsatz/{firecallId}/details` in einem neuen Tab zu öffnen.
+
+### 2. Neuer Hook: `useCrewAssignments`
+
+- Datei: `chrome-extension/src/popup/hooks/useCrewAssignments.ts`
+- Analog zu `useFirecallItems` — `onSnapshot` auf `call/{firecallId}/crew`
+- Gibt `{ crew: CrewAssignment[], loading: boolean }` zurück
+
+### 3. Type-Exports erweitern
+
+`chrome-extension/src/shared/types.ts` exportiert zusätzlich `CrewAssignment`, `funktionAbkuerzung` und die `FIRECALL_CREW_COLLECTION_ID` Konstante aus der Hauptapp.
+
+### 4. Erweiterte `FirecallOverview`
+
+**Kopfbereich** (wie bisher, aber Name als Link):
+- Firecall-Name → klickbar, öffnet Detailseite
+- Status-Chip (Aktiv/Beendet)
+- Beschreibung, Datum
+
+**Fahrzeuge mit Mannschaft** (neu, nach dem Divider):
+- Jedes Fahrzeug als Abschnitt: Name + FW in Fettschrift
+- Darunter zugeordnete Crew-Mitglieder: Funktions-Abkürzung + Name
+- Fahrzeuge ohne Crew werden trotzdem angezeigt
+- Personen ohne Fahrzeug in einer "Ohne Fahrzeug"-Gruppe
+- Wenn keine Fahrzeuge und keine Crew vorhanden: nichts zusätzliches anzeigen
+
+### 5. Datenfluss
+
+`App.tsx`:
+- Ruft `useCrewAssignments(selectedFirecallId)` auf
+- Gibt `crew`, `firecallId` als zusätzliche Props an `FirecallOverview`
+
+## Dateien
+
+| Datei | Aktion |
+|---|---|
+| `chrome-extension/src/shared/types.ts` | Erweitern: CrewAssignment, funktionAbkuerzung, FIRECALL_CREW_COLLECTION_ID exportieren |
+| `chrome-extension/src/popup/hooks/useCrewAssignments.ts` | Neu: Firestore-Subscription auf crew subcollection |
+| `chrome-extension/src/popup/components/FirecallOverview.tsx` | Erweitern: Link auf Titel, Fahrzeuge + Crew gruppiert anzeigen |
+| `chrome-extension/src/popup/App.tsx` | Erweitern: useCrewAssignments einbinden, Props durchreichen |


### PR DESCRIPTION
## Zusammenfassung

Automatisiertes Publizieren der Chrome Extension im Chrome Web Store sowie Erweiterungen der Popup-Übersicht um Fahrzeuge und Mannschaft.

## Änderungen

- CWS Publish Script (`publish-cws.mjs`) zum automatischen Upload und Veröffentlichen im Chrome Web Store
- CI Workflow Integration: Release-Workflow nutzt das neue Publish Script
- Popup-Übersicht zeigt jetzt Fahrzeuge und Mannschaftszuordnungen an, Titel verlinkt zur Detailseite
- Firecall-Auswahl wird zurückgesetzt wenn die gespeicherte ID nicht mehr existiert
- Manifest Key bleibt in `dist/` für stabile Extension-ID bei entpackter Installation
- Chunk Size Warning Limit auf 600 kB erhöht (Popup-Bundle 501 kB, lokal geladen)
- CWS Publish Dokumentation im README
- `.envrc` zu `.gitignore` hinzugefügt

## Test plan

- [ ] `npm run build` in `chrome-extension/` läuft ohne Warnings
- [ ] Extension in Chrome laden und Popup öffnen: Fahrzeuge und Crew werden angezeigt
- [ ] Titel in der Übersicht verlinkt korrekt zur Detailseite
- [ ] `npm run publish:cws` mit gültigen Credentials veröffentlicht erfolgreich
- [ ] CI Workflow `chrome-extension-release.yml` nutzt `publish-cws.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)