### PR TITLE
feat(einsatz): Einsatz ohne Blaulicht-SMS anlegen

### DIFF
--- a/src/common/stripNullish.test.ts
+++ b/src/common/stripNullish.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { stripNullish } from './stripNullish';
+
+describe('stripNullish', () => {
+  it('removes undefined and null values', () => {
+    const input = {
+      a: 'hello',
+      b: undefined,
+      c: null,
+      d: 0,
+      e: '',
+      f: false,
+    };
+
+    const result = stripNullish(input);
+
+    expect(result).toEqual({ a: 'hello', d: 0, e: '', f: false });
+    expect('b' in result).toBe(false);
+    expect('c' in result).toBe(false);
+  });
+
+  it('preserves nested objects as-is', () => {
+    const nested = { foo: 'bar' };
+    const result = stripNullish({ nested, skip: undefined });
+
+    expect(result.nested).toBe(nested);
+    expect('skip' in result).toBe(false);
+  });
+});

--- a/src/common/stripNullish.ts
+++ b/src/common/stripNullish.ts
@@ -1,0 +1,12 @@
+// Firestore does not accept `undefined` — strip both `undefined` and `null`
+// before persisting documents.
+export function stripNullish<T extends Record<string, any>>(obj: T): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key of Object.keys(obj) as (keyof T)[]) {
+    const value = obj[key];
+    if (value !== undefined && value !== null) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/components/FirecallItems/EinsatzDialog.tsx
+++ b/src/components/FirecallItems/EinsatzDialog.tsx
@@ -24,7 +24,7 @@ import {
 import { StorageReference } from 'firebase/storage';
 import { useCallback, useEffect, useState } from 'react';
 import { GeoPositionObject } from '../../common/geo';
-import { formatTimestamp, parseTimestamp } from '../../common/time-format';
+import { parseTimestamp } from '../../common/time-format';
 import { defaultPosition } from '../../hooks/constants';
 import useFirebaseLogin from '../../hooks/useFirebaseLogin';
 import { useFirecallSelect } from '../../hooks/useFirecall';
@@ -39,6 +39,11 @@ import {
   BlaulichtSmsAlarm,
 } from '../../app/blaulicht-sms/actions';
 import { getGroupsWithBlaulichtsmsConfig } from '../../app/blaulicht-sms/credentialsActions';
+import {
+  createDefaultEinsatz,
+  resetEinsatzToManual,
+  stripNullish,
+} from './einsatzDefaults';
 
 export interface EinsatzDialogOptions {
   onClose: (einsatz?: Firecall) => void;
@@ -53,15 +58,7 @@ export default function EinsatzDialog({
 }: EinsatzDialogOptions) {
   const [open, setOpen] = useState(true);
   const [einsatz, setEinsatz] = useState<Firecall>(
-    einsatzDefault || {
-      name: `Einsatz am ${formatTimestamp(new Date())}`,
-      group: 'ffnd',
-      fw: 'Neusiedl am See',
-      description: '',
-      date: new Date().toISOString(),
-      eintreffen: new Date().toISOString(),
-      deleted: false,
-    }
+    einsatzDefault || createDefaultEinsatz()
   );
   const { email, myGroups } = useFirebaseLogin();
   const setFirecallId = useFirecallSelect();
@@ -150,6 +147,8 @@ export default function EinsatzDialog({
             setEinsatz((prev) => ({ ...prev, blaulichtSmsAlarmId: alarm.alarmId }));
           }
         }
+      } else if (isNewEinsatz) {
+        setEinsatz((prev) => resetEinsatzToManual(prev));
       } else {
         setEinsatz((prev) => ({ ...prev, blaulichtSmsAlarmId: undefined }));
       }
@@ -185,26 +184,27 @@ export default function EinsatzDialog({
 
   const saveEinsatz = useCallback(
     async (fc: Firecall) => {
-      // if (!fc.sheetId) {
-      //   fc.sheetId = await copyFirecallSheet(fc);
-      // }
-
       if (fc.id) {
         // update
+        const updatePayload = stripNullish({
+          ...fc,
+          updatedAt: new Date().toISOString(),
+          updatedBy: email,
+        });
         await setDoc(
           doc(firestore, FIRECALL_COLLECTION_ID, fc.id),
-          { ...fc, updatedAt: new Date().toISOString(), updatedBy: email },
+          updatePayload,
           { merge: true }
         );
       } else {
         //save new
-        const firecallData: Firecall = {
+        const firecallData = stripNullish({
           ...fc,
           user: email,
           created: new Date().toISOString(),
           lat: fc.lat ?? position.lat,
           lng: fc.lng ?? position.lng,
-        };
+        });
         const newDoc = await addDoc(
           collection(firestore, FIRECALL_COLLECTION_ID),
           firecallData

--- a/src/components/FirecallItems/EinsatzDialog.tsx
+++ b/src/components/FirecallItems/EinsatzDialog.tsx
@@ -39,11 +39,8 @@ import {
   BlaulichtSmsAlarm,
 } from '../../app/blaulicht-sms/actions';
 import { getGroupsWithBlaulichtsmsConfig } from '../../app/blaulicht-sms/credentialsActions';
-import {
-  createDefaultEinsatz,
-  resetEinsatzToManual,
-  stripNullish,
-} from './einsatzDefaults';
+import { stripNullish } from '../../common/stripNullish';
+import { createDefaultEinsatz, resetEinsatzToManual } from './einsatzDefaults';
 
 export interface EinsatzDialogOptions {
   onClose: (einsatz?: Firecall) => void;

--- a/src/components/FirecallItems/einsatzDefaults.test.ts
+++ b/src/components/FirecallItems/einsatzDefaults.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createDefaultEinsatz,
+  DEFAULT_EINSATZ_FW,
+  DEFAULT_EINSATZ_GROUP,
+  resetEinsatzToManual,
+  stripNullish,
+} from './einsatzDefaults';
+import { Firecall } from '../firebase/firestore';
+
+describe('createDefaultEinsatz', () => {
+  it('produces default values based on the given date', () => {
+    const now = new Date('2026-04-18T12:34:56.000Z');
+    const einsatz = createDefaultEinsatz(now);
+
+    expect(einsatz.group).toBe(DEFAULT_EINSATZ_GROUP);
+    expect(einsatz.fw).toBe(DEFAULT_EINSATZ_FW);
+    expect(einsatz.description).toBe('');
+    expect(einsatz.deleted).toBe(false);
+    expect(einsatz.date).toBe(now.toISOString());
+    expect(einsatz.eintreffen).toBe(now.toISOString());
+    expect(einsatz.name).toMatch(/^Einsatz am /);
+  });
+
+  it('respects overrides', () => {
+    const now = new Date('2026-04-18T12:00:00.000Z');
+    const einsatz = createDefaultEinsatz(now, { group: 'other', fw: 'Test FW' });
+
+    expect(einsatz.group).toBe('other');
+    expect(einsatz.fw).toBe('Test FW');
+  });
+});
+
+describe('resetEinsatzToManual', () => {
+  it('clears alarm-derived fields and resets date/eintreffen to now', () => {
+    const now = new Date('2026-04-18T08:00:00.000Z');
+    const current: Firecall = {
+      name: 'Von Alarm befüllt',
+      group: 'ffnd',
+      fw: 'Neusiedl am See',
+      description: 'alter Alarmtext',
+      date: '2026-04-17T10:00:00.000Z',
+      eintreffen: '2026-04-17T10:05:00.000Z',
+      abruecken: '2026-04-17T11:00:00.000Z',
+      lat: 47.95,
+      lng: 16.84,
+      blaulichtSmsAlarmId: 'alarm-123',
+    };
+
+    const reset = resetEinsatzToManual(current, now);
+
+    expect(reset.description).toBe('');
+    expect(reset.date).toBe(now.toISOString());
+    expect(reset.eintreffen).toBe(now.toISOString());
+    expect(reset.abruecken).toBeUndefined();
+    expect(reset.lat).toBeUndefined();
+    expect(reset.lng).toBeUndefined();
+    expect(reset.blaulichtSmsAlarmId).toBeUndefined();
+    expect(reset.name).toMatch(/^Einsatz am /);
+  });
+
+  it('preserves group and fw and empty-string values', () => {
+    const now = new Date('2026-04-18T08:00:00.000Z');
+    const current: Firecall = {
+      name: 'Test',
+      group: 'custom-group',
+      fw: 'Custom FW',
+      blaulichtSmsAlarmId: 'x',
+    };
+
+    const reset = resetEinsatzToManual(current, now);
+
+    expect(reset.group).toBe('custom-group');
+    expect(reset.fw).toBe('Custom FW');
+  });
+});
+
+describe('stripNullish', () => {
+  it('removes undefined and null values', () => {
+    const input = {
+      a: 'hello',
+      b: undefined,
+      c: null,
+      d: 0,
+      e: '',
+      f: false,
+    };
+
+    const result = stripNullish(input);
+
+    expect(result).toEqual({ a: 'hello', d: 0, e: '', f: false });
+    expect('b' in result).toBe(false);
+    expect('c' in result).toBe(false);
+  });
+
+  it('preserves nested objects as-is', () => {
+    const nested = { foo: 'bar' };
+    const result = stripNullish({ nested, skip: undefined });
+
+    expect(result.nested).toBe(nested);
+    expect('skip' in result).toBe(false);
+  });
+});

--- a/src/components/FirecallItems/einsatzDefaults.test.ts
+++ b/src/components/FirecallItems/einsatzDefaults.test.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_EINSATZ_FW,
   DEFAULT_EINSATZ_GROUP,
   resetEinsatzToManual,
-  stripNullish,
 } from './einsatzDefaults';
 import { Firecall } from '../firebase/firestore';
 
@@ -72,32 +71,5 @@ describe('resetEinsatzToManual', () => {
 
     expect(reset.group).toBe('custom-group');
     expect(reset.fw).toBe('Custom FW');
-  });
-});
-
-describe('stripNullish', () => {
-  it('removes undefined and null values', () => {
-    const input = {
-      a: 'hello',
-      b: undefined,
-      c: null,
-      d: 0,
-      e: '',
-      f: false,
-    };
-
-    const result = stripNullish(input);
-
-    expect(result).toEqual({ a: 'hello', d: 0, e: '', f: false });
-    expect('b' in result).toBe(false);
-    expect('c' in result).toBe(false);
-  });
-
-  it('preserves nested objects as-is', () => {
-    const nested = { foo: 'bar' };
-    const result = stripNullish({ nested, skip: undefined });
-
-    expect(result.nested).toBe(nested);
-    expect('skip' in result).toBe(false);
   });
 });

--- a/src/components/FirecallItems/einsatzDefaults.ts
+++ b/src/components/FirecallItems/einsatzDefaults.ts
@@ -1,17 +1,6 @@
 import { formatTimestamp } from '../../common/time-format';
 import { Firecall } from '../firebase/firestore';
 
-export function stripNullish<T extends Record<string, any>>(obj: T): Partial<T> {
-  const result: Partial<T> = {};
-  for (const key of Object.keys(obj) as (keyof T)[]) {
-    const value = obj[key];
-    if (value !== undefined && value !== null) {
-      result[key] = value;
-    }
-  }
-  return result;
-}
-
 export const DEFAULT_EINSATZ_GROUP = 'ffnd';
 export const DEFAULT_EINSATZ_FW = 'Neusiedl am See';
 

--- a/src/components/FirecallItems/einsatzDefaults.ts
+++ b/src/components/FirecallItems/einsatzDefaults.ts
@@ -1,0 +1,49 @@
+import { formatTimestamp } from '../../common/time-format';
+import { Firecall } from '../firebase/firestore';
+
+export function stripNullish<T extends Record<string, any>>(obj: T): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key of Object.keys(obj) as (keyof T)[]) {
+    const value = obj[key];
+    if (value !== undefined && value !== null) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export const DEFAULT_EINSATZ_GROUP = 'ffnd';
+export const DEFAULT_EINSATZ_FW = 'Neusiedl am See';
+
+export function createDefaultEinsatz(
+  now: Date = new Date(),
+  overrides: Partial<Firecall> = {},
+): Firecall {
+  return {
+    name: `Einsatz am ${formatTimestamp(now)}`,
+    group: DEFAULT_EINSATZ_GROUP,
+    fw: DEFAULT_EINSATZ_FW,
+    description: '',
+    date: now.toISOString(),
+    eintreffen: now.toISOString(),
+    deleted: false,
+    ...overrides,
+  };
+}
+
+export function resetEinsatzToManual(
+  current: Firecall,
+  now: Date = new Date(),
+): Firecall {
+  return {
+    ...current,
+    name: `Einsatz am ${formatTimestamp(now)}`,
+    description: '',
+    date: now.toISOString(),
+    eintreffen: now.toISOString(),
+    abruecken: undefined,
+    lat: undefined,
+    lng: undefined,
+    blaulichtSmsAlarmId: undefined,
+  };
+}

--- a/src/hooks/useKostenersatzMutations.ts
+++ b/src/hooks/useKostenersatzMutations.ts
@@ -27,16 +27,10 @@ import {
   KOSTENERSATZ_VERSIONS_COLLECTION,
 } from '../common/kostenersatz';
 import { getDefaultVehicles } from '../common/defaultKostenersatzRates';
+import { stripNullish } from '../common/stripNullish';
 import useFirebaseLogin from './useFirebaseLogin';
 import { useFirecallId } from './useFirecall';
 import { useAuditLog } from './useAuditLog';
-
-// Helper to remove undefined values (Firestore doesn't accept undefined)
-function removeUndefined<T extends object>(obj: T): T {
-  return Object.fromEntries(
-    Object.entries(obj).filter(([_, v]) => v !== undefined)
-  ) as T;
-}
 
 // ============================================================================
 // Calculation Mutations
@@ -76,7 +70,7 @@ export function useKostenersatzAdd(firecallIdOverride?: string) {
           firecallId,
           KOSTENERSATZ_SUBCOLLECTION
         ),
-        removeUndefined(newCalc)
+        stripNullish(newCalc)
       );
 
       logChange({
@@ -134,7 +128,7 @@ export function useKostenersatzUpdate(firecallIdOverride?: string) {
           KOSTENERSATZ_SUBCOLLECTION,
           calcId
         ),
-        removeUndefined(dataWithoutId),
+        stripNullish(dataWithoutId),
         { merge: false }
       );
 
@@ -240,7 +234,7 @@ export function useKostenersatzTemplateAdd() {
 
       const docRef = await addDoc(
         collection(firestore, KOSTENERSATZ_TEMPLATES_COLLECTION),
-        removeUndefined(newTemplate)
+        stripNullish(newTemplate)
       );
 
       return docRef.id;
@@ -270,7 +264,7 @@ export function useKostenersatzTemplateUpdate() {
 
     await setDoc(
       doc(firestore, KOSTENERSATZ_TEMPLATES_COLLECTION, templateId),
-      removeUndefined(dataWithoutId),
+      stripNullish(dataWithoutId),
       { merge: false }
     );
   }, []);
@@ -396,7 +390,7 @@ export function useKostenersatzRateUpsert() {
 
     await setDoc(
       doc(firestore, KOSTENERSATZ_RATES_COLLECTION, docId),
-      removeUndefined(rate)
+      stripNullish(rate)
     );
   }, []);
 }
@@ -489,7 +483,7 @@ export function useKostenersatzVehicleUpsert() {
 
     await setDoc(
       doc(firestore, KOSTENERSATZ_VEHICLES_COLLECTION, vehicle.id),
-      removeUndefined(vehicle)
+      stripNullish(vehicle)
     );
   }, []);
 }


### PR DESCRIPTION
- Beim Wechsel auf "Manuell eingeben" werden Name, Beschreibung,
  Alarmierungs- und Eintreffzeit sowie Koordinaten zurückgesetzt und
  das Datum auf den aktuellen Zeitpunkt gesetzt.
- Standardwerte für neue Einsätze in helper ausgelagert
  (createDefaultEinsatz, resetEinsatzToManual).
- Firestore-Speichern entfernt nullish-Werte, damit keine undefined-
  oder null-Felder an Firestore gesendet werden.