### PR TITLE
fix: auto-renew auth after standby and surface save errors

### DIFF
--- a/src/hooks/auth/ensureFreshAuth.test.ts
+++ b/src/hooks/auth/ensureFreshAuth.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockUser = {
+  getIdToken: ReturnType<typeof vi.fn>;
+  getIdTokenResult: ReturnType<typeof vi.fn>;
+};
+
+const hoisted = vi.hoisted(() => ({
+  mockAuth: { currentUser: null as MockUser | null },
+  firebaseTokenLoginMock: vi.fn(),
+}));
+
+vi.mock('../../components/firebase/firebase', () => ({
+  auth: hoisted.mockAuth,
+}));
+
+vi.mock('../../app/firebaseAuth', () => ({
+  firebaseTokenLogin: (token: string) => hoisted.firebaseTokenLoginMock(token),
+}));
+
+const { mockAuth, firebaseTokenLoginMock } = hoisted;
+
+import { ensureFreshAuth, isAuthError } from './ensureFreshAuth';
+
+function makeUser(expirationOffsetMs: number): MockUser {
+  const expirationTime = new Date(Date.now() + expirationOffsetMs).toISOString();
+  return {
+    getIdToken: vi.fn().mockResolvedValue('fresh-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({ expirationTime }),
+  };
+}
+
+describe('ensureFreshAuth', () => {
+  beforeEach(() => {
+    mockAuth.currentUser = null;
+    firebaseTokenLoginMock.mockReset();
+    firebaseTokenLoginMock.mockResolvedValue({ ok: true });
+  });
+
+  it('returns false when there is no current user', async () => {
+    const result = await ensureFreshAuth();
+    expect(result).toBe(false);
+    expect(firebaseTokenLoginMock).not.toHaveBeenCalled();
+  });
+
+  it('skips token refresh when token is fresh', async () => {
+    const user = makeUser(30 * 60 * 1000);
+    mockAuth.currentUser = user;
+
+    const result = await ensureFreshAuth();
+
+    expect(result).toBe(true);
+    expect(user.getIdToken).not.toHaveBeenCalledWith(true);
+    expect(firebaseTokenLoginMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes Firebase token and server session when token is near expiry', async () => {
+    const user = makeUser(60 * 1000); // expires in 60s
+    mockAuth.currentUser = user;
+
+    const result = await ensureFreshAuth();
+
+    expect(result).toBe(true);
+    expect(user.getIdToken).toHaveBeenCalledWith(true);
+    expect(firebaseTokenLoginMock).toHaveBeenCalledWith('fresh-token');
+  });
+
+  it('forces a server login when forceServerLogin is true, even with fresh token', async () => {
+    const user = makeUser(30 * 60 * 1000);
+    mockAuth.currentUser = user;
+
+    await ensureFreshAuth(true);
+
+    expect(firebaseTokenLoginMock).toHaveBeenCalledWith('fresh-token');
+  });
+
+  it('returns false when server login fails', async () => {
+    const user = makeUser(60 * 1000);
+    mockAuth.currentUser = user;
+    firebaseTokenLoginMock.mockResolvedValueOnce({ error: 'signin failed' });
+
+    const result = await ensureFreshAuth();
+
+    expect(result).toBe(false);
+  });
+
+  it('de-duplicates concurrent callers', async () => {
+    const user = makeUser(60 * 1000);
+    mockAuth.currentUser = user;
+
+    const [a, b, c] = await Promise.all([
+      ensureFreshAuth(),
+      ensureFreshAuth(),
+      ensureFreshAuth(),
+    ]);
+
+    expect([a, b, c]).toEqual([true, true, true]);
+    expect(user.getIdToken).toHaveBeenCalledWith(true);
+    expect(user.getIdToken).toHaveBeenCalledTimes(2); // once with true, once without
+    expect(firebaseTokenLoginMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isAuthError', () => {
+  it('detects Firestore permission-denied errors by code', () => {
+    expect(isAuthError({ code: 'permission-denied' })).toBe(true);
+  });
+
+  it('detects Firebase auth error codes', () => {
+    expect(isAuthError({ code: 'auth/id-token-expired' })).toBe(true);
+  });
+
+  it('detects unauthenticated errors by code', () => {
+    expect(isAuthError({ code: 'unauthenticated' })).toBe(true);
+  });
+
+  it('detects auth errors by message text', () => {
+    expect(
+      isAuthError(new Error('Missing or insufficient permissions.')),
+    ).toBe(true);
+  });
+
+  it('returns false for network errors', () => {
+    expect(isAuthError({ code: 'unavailable' })).toBe(false);
+  });
+
+  it('returns false for unknown errors', () => {
+    expect(isAuthError(new Error('Something else went wrong'))).toBe(false);
+  });
+});

--- a/src/hooks/auth/ensureFreshAuth.ts
+++ b/src/hooks/auth/ensureFreshAuth.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { auth } from '../../components/firebase/firebase';
+import { firebaseTokenLogin } from '../../app/firebaseAuth';
+
+const TOKEN_MIN_LIFETIME_MS = 5 * 60 * 1000;
+
+let inflight: Promise<boolean> | null = null;
+
+function isAuthError(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code;
+  if (typeof code === 'string') {
+    if (
+      code === 'permission-denied' ||
+      code === 'unauthenticated' ||
+      code.startsWith('auth/')
+    ) {
+      return true;
+    }
+  }
+  const message = (err as { message?: string } | null)?.message || '';
+  return (
+    /permission[-_ ]denied/i.test(message) ||
+    /unauthenticated/i.test(message) ||
+    /missing or insufficient permissions/i.test(message)
+  );
+}
+
+async function doEnsure(forceServerLogin: boolean): Promise<boolean> {
+  const user = auth.currentUser;
+  if (!user) return false;
+
+  const tokenResult = await user.getIdTokenResult();
+  const expirationMs = Date.parse(tokenResult.expirationTime);
+  const needsTokenRefresh =
+    Number.isNaN(expirationMs) ||
+    expirationMs - Date.now() < TOKEN_MIN_LIFETIME_MS;
+
+  if (needsTokenRefresh) {
+    await user.getIdToken(true);
+  }
+
+  if (needsTokenRefresh || forceServerLogin) {
+    const token = await user.getIdToken();
+    if (!token) return false;
+    const result = await firebaseTokenLogin(token);
+    if (result && typeof result === 'object' && 'error' in result && result.error) {
+      console.warn('ensureFreshAuth: firebaseTokenLogin failed', result.error);
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Ensure the Firebase ID token is valid and the NextAuth session is fresh.
+ * De-duplicates concurrent callers and only performs network work when the
+ * current token is close to expiring (unless `forceServerLogin` is true).
+ * Returns false when refreshing failed so callers can decide what to do.
+ */
+export async function ensureFreshAuth(
+  forceServerLogin = false,
+): Promise<boolean> {
+  if (inflight) return inflight;
+  inflight = doEnsure(forceServerLogin).catch((err) => {
+    console.error('ensureFreshAuth failed', err);
+    return false;
+  });
+  try {
+    return await inflight;
+  } finally {
+    inflight = null;
+  }
+}
+
+export { isAuthError };

--- a/src/hooks/auth/withFreshAuth.test.ts
+++ b/src/hooks/auth/withFreshAuth.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  ensureFreshAuth: vi.fn(),
+}));
+
+vi.mock('./ensureFreshAuth', () => ({
+  ensureFreshAuth: hoisted.ensureFreshAuth,
+  isAuthError: (err: unknown) => {
+    const code = (err as { code?: string } | null)?.code;
+    return (
+      code === 'permission-denied' ||
+      code === 'unauthenticated' ||
+      (typeof code === 'string' && code.startsWith('auth/'))
+    );
+  },
+}));
+
+import { withFreshAuth } from './withFreshAuth';
+
+describe('withFreshAuth', () => {
+  beforeEach(() => {
+    hoisted.ensureFreshAuth.mockReset();
+    hoisted.ensureFreshAuth.mockResolvedValue(true);
+  });
+
+  it('runs the operation after a pre-refresh and returns its result', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+    const result = await withFreshAuth(op);
+    expect(result).toBe('ok');
+    expect(hoisted.ensureFreshAuth).toHaveBeenCalledTimes(1);
+    expect(hoisted.ensureFreshAuth).toHaveBeenLastCalledWith();
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once after forced refresh on auth errors', async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce({ code: 'permission-denied' })
+      .mockResolvedValueOnce('ok');
+
+    const result = await withFreshAuth(op);
+
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(hoisted.ensureFreshAuth).toHaveBeenCalledTimes(2);
+    expect(hoisted.ensureFreshAuth).toHaveBeenLastCalledWith(true);
+  });
+
+  it('does not retry non-auth errors', async () => {
+    const networkErr = { code: 'unavailable' };
+    const op = vi.fn().mockRejectedValue(networkErr);
+
+    await expect(withFreshAuth(op)).rejects.toBe(networkErr);
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(hoisted.ensureFreshAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws original auth error when forced refresh fails', async () => {
+    const authErr = { code: 'unauthenticated' };
+    const op = vi.fn().mockRejectedValue(authErr);
+    hoisted.ensureFreshAuth
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    await expect(withFreshAuth(op)).rejects.toBe(authErr);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/auth/withFreshAuth.ts
+++ b/src/hooks/auth/withFreshAuth.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { ensureFreshAuth, isAuthError } from './ensureFreshAuth';
+
+/**
+ * Execute a Firestore (or other auth-gated) operation after making sure the
+ * current session is fresh. If the operation fails with an auth error we
+ * retry exactly once after forcing a full auth refresh, so a token that went
+ * stale during standby is renewed transparently.
+ */
+export async function withFreshAuth<T>(op: () => Promise<T>): Promise<T> {
+  await ensureFreshAuth();
+  try {
+    return await op();
+  } catch (err) {
+    if (!isAuthError(err)) throw err;
+    console.warn('auth-related error, retrying after forced refresh', err);
+    const refreshed = await ensureFreshAuth(true);
+    if (!refreshed) throw err;
+    return await op();
+  }
+}

--- a/src/hooks/useFirebaseLoginObserver.ts
+++ b/src/hooks/useFirebaseLoginObserver.ts
@@ -20,6 +20,7 @@ import {
   loadAuthFromSessionStorage,
   saveAuthToSessionStorage,
 } from './auth/sessionStorage';
+import { ensureFreshAuth } from './auth/ensureFreshAuth';
 import { loginTimer } from '../common/loginTiming';
 
 // Re-export types for backward compatibility
@@ -229,25 +230,56 @@ export default function useFirebaseLoginObserver(): LoginStatus {
     return () => clearInterval(clearServerInterval);
   }, [serverLogin]);
 
-  // Refresh session when tab becomes visible, but only if session is stale (>5 min)
+  // Refresh session when the app wakes up (tab visible, window focused,
+  // page shown from bfcache, or network reconnected). Device standby pauses
+  // JS timers, so any of these is the first signal that we are back and
+  // should verify that the Firebase token + NextAuth session are still fresh.
   useEffect(() => {
-    const SESSION_STALE_MS = 5 * 60 * 1000;
-    const handleVisibilityChange = async () => {
-      if (document.visibilityState === 'visible' && auth.currentUser) {
-        const elapsed = Date.now() - lastRefreshRef.current;
-        if (elapsed >= SESSION_STALE_MS) {
-          console.info(
-            `tab became visible, refreshing session (last refresh ${Math.round(elapsed / 1000)}s ago)`
-          );
-          await serverLogin();
+    const SESSION_STALE_MS = 60 * 1000;
+    let isRunning = false;
+
+    const maybeRefresh = async (reason: string, force = false) => {
+      if (!auth.currentUser) return;
+      if (isRunning) return;
+      const elapsed = Date.now() - lastRefreshRef.current;
+      if (!force && elapsed < SESSION_STALE_MS) return;
+      isRunning = true;
+      try {
+        console.info(
+          `${reason}, refreshing session (last refresh ${Math.round(elapsed / 1000)}s ago)`
+        );
+        const ok = await ensureFreshAuth(true);
+        if (ok) {
           lastRefreshRef.current = Date.now();
+        } else {
+          console.warn(`session refresh failed after ${reason}`);
         }
+      } finally {
+        isRunning = false;
       }
     };
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void maybeRefresh('tab became visible');
+      }
+    };
+    const handleFocus = () => void maybeRefresh('window focused');
+    const handlePageShow = (event: PageTransitionEvent) =>
+      void maybeRefresh('page shown', event.persisted);
+    const handleOnline = () => void maybeRefresh('network back online', true);
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [serverLogin]);
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('pageshow', handlePageShow);
+    window.addEventListener('online', handleOnline);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('pageshow', handlePageShow);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, []);
 
   const fbSignOut = useCallback(async () => {
     clearAuthFromSessionStorage();

--- a/src/hooks/useFirecallItemAdd.ts
+++ b/src/hooks/useFirecallItemAdd.ts
@@ -10,6 +10,8 @@ import { useSnackbar } from '../components/providers/SnackbarProvider';
 import useFirebaseLogin from './useFirebaseLogin';
 import { useFirecallId } from './useFirecall';
 import { useAuditLog } from './useAuditLog';
+import { withFreshAuth } from './auth/withFreshAuth';
+import { isAuthError } from './auth/ensureFreshAuth';
 
 export default function useFirecallItemAdd() {
   const firecallId = useFirecallId();
@@ -42,14 +44,16 @@ export default function useFirecallItemAdd() {
       );
 
       try {
-        const docRef = await addDoc(
-          collection(
-            firestore,
-            FIRECALL_COLLECTION_ID,
-            firecallId,
-            itemClass.firebaseCollectionName()
-          ),
-          newData
+        const docRef = await withFreshAuth(() =>
+          addDoc(
+            collection(
+              firestore,
+              FIRECALL_COLLECTION_ID,
+              firecallId,
+              itemClass.firebaseCollectionName()
+            ),
+            newData
+          )
         );
 
         logChange({
@@ -63,10 +67,23 @@ export default function useFirecallItemAdd() {
         return docRef;
       } catch (err) {
         console.error('Failed to add firecall item:', err);
-        showSnackbar(
-          'Element konnte nicht gespeichert werden. Bitte Verbindung und Anmeldung prüfen.',
-          'error',
-        );
+        const reloadAction = {
+          label: 'Neu laden',
+          onClick: () => window.location.reload(),
+        };
+        if (isAuthError(err)) {
+          showSnackbar(
+            'Sitzung abgelaufen. Element wurde nicht gespeichert. Bitte Seite neu laden und erneut anmelden.',
+            'error',
+            reloadAction,
+          );
+        } else {
+          showSnackbar(
+            'Element konnte nicht gespeichert werden. Bitte Verbindung prüfen und erneut versuchen.',
+            'error',
+            reloadAction,
+          );
+        }
         throw err;
       }
     },

--- a/src/hooks/useFirecallItemUpdate.ts
+++ b/src/hooks/useFirecallItemUpdate.ts
@@ -22,6 +22,8 @@ import { useSnackbar } from '../components/providers/SnackbarProvider';
 import useFirebaseLogin from './useFirebaseLogin';
 import { useFirecallId } from './useFirecall';
 import { useAuditLog } from './useAuditLog';
+import { withFreshAuth } from './auth/withFreshAuth';
+import { isAuthError } from './auth/ensureFreshAuth';
 
 export default function useFirecallItemUpdate() {
   const firecallId = useFirecallId();
@@ -49,16 +51,18 @@ export default function useFirecallItemUpdate() {
       );
 
       try {
-        await setDoc(
-          doc(
-            firestore,
-            FIRECALL_COLLECTION_ID,
-            firecallId,
-            itemClass.firebaseCollectionName(),
-            '' + item.id
-          ),
-          newData,
-          { merge: false }
+        await withFreshAuth(() =>
+          setDoc(
+            doc(
+              firestore,
+              FIRECALL_COLLECTION_ID,
+              firecallId,
+              itemClass.firebaseCollectionName(),
+              '' + item.id
+            ),
+            newData,
+            { merge: false }
+          )
         );
 
         // When a layer is deleted, cascade to all items in that layer
@@ -134,10 +138,23 @@ export default function useFirecallItemUpdate() {
         });
       } catch (err) {
         console.error('Failed to update firecall item:', err);
-        showSnackbar(
-          'Element konnte nicht aktualisiert werden. Bitte Verbindung und Anmeldung prüfen.',
-          'error',
-        );
+        const reloadAction = {
+          label: 'Neu laden',
+          onClick: () => window.location.reload(),
+        };
+        if (isAuthError(err)) {
+          showSnackbar(
+            'Sitzung abgelaufen. Änderung wurde nicht gespeichert. Bitte Seite neu laden und erneut anmelden.',
+            'error',
+            reloadAction,
+          );
+        } else {
+          showSnackbar(
+            'Element konnte nicht aktualisiert werden. Bitte Verbindung prüfen und erneut versuchen.',
+            'error',
+            reloadAction,
+          );
+        }
         throw err;
       }
     },


### PR DESCRIPTION
## Zusammenfassung

Nach längerer Inaktivität des Geräts (Standby) lief die Authentifizierung
ab, ohne automatisch erneuert zu werden. In der PWA konnten Elemente
zwar noch hinzugefügt werden, wurden aber nicht nach Firestore
synchronisiert — ohne sichtbares Feedback. Beim Neuladen waren die
Änderungen verloren.

Dieser PR macht die Session-Erneuerung nach Standby robust (mehr
Wake-Events, niedrigere Schwelle, Token-Refresh plus Server-Login) und
sorgt dafür, dass fehlgeschlagene Speicherungen sofort als klare
Fehlermeldung mit Aktion "Neu laden" angezeigt werden.

## Änderungen

- Neuer Helper `ensureFreshAuth()` in `src/hooks/auth/ensureFreshAuth.ts`
  - Prüft Firebase-Token-Ablauf (Schwelle 5 min) und erzwingt bei Bedarf
    `getIdToken(true)` + NextAuth-Session-Refresh via `firebaseTokenLogin`
  - Dedupliziert parallele Aufrufer mit einem In-Flight-Promise
  - Exportiert `isAuthError()` zur Erkennung auth-bedingter Firestore-/
    Firebase-Auth-Fehler
- Neuer Wrapper `withFreshAuth()` in `src/hooks/auth/withFreshAuth.ts`
  - Pre-Check vor dem Firestore-Write
  - Bei auth-bedingtem Fehler genau ein Retry nach erzwungenem Refresh
- `useFirebaseLoginObserver`:
  - Stale-Schwelle für Wake-Refresh von 5 min auf 1 min gesenkt
  - Zusätzlich zu `visibilitychange` werden jetzt auch `focus`,
    `pageshow` und `online` abonniert (manche Geräte/Browser feuern
    `visibilitychange` nach Standby nicht zuverlässig)
  - Wake-Refresh läuft über `ensureFreshAuth(true)` und ist reentrant-sicher
- `useFirecallItemAdd` und `useFirecallItemUpdate` nutzen `withFreshAuth`
  - Klare Fehlermeldungen: Auth-Fehler → "Sitzung abgelaufen …",
    sonst "Bitte Verbindung prüfen …"
  - Snackbar enthält Aktion "Neu laden" zum schnellen Recovery
- Neue Vitest-Tests (16 Tests) für beide Helfer

## Test plan

- [ ] `npm run test -- src/hooks/auth/` läuft grün
- [ ] `npm run lint` und `npx tsc --noEmit` ohne Fehler
- [ ] Manuell: Gerät in Standby schicken, nach >1 min aufwecken → Konsole
      zeigt `tab became visible, refreshing session …` bzw.
      `window focused …` und die Session wird erneuert
- [ ] Manuell: Element im PWA anlegen, während die Session serverseitig
      invalidiert ist → Snackbar zeigt "Sitzung abgelaufen. Element wurde
      nicht gespeichert." mit "Neu laden"-Button; das Element erscheint
      nach Re-Login korrekt in Firestore
- [ ] Manuell: Bei kurzfristigem Netzwerkverlust während des Speicherns
      wird ein auth-unabhängiger Fehler mit "Element konnte nicht
      gespeichert werden. Bitte Verbindung prüfen …" angezeigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)