### PR TITLE
feat(spektrogramm): Peaks und manuelle Nuklid-Zuordnung

### DIFF
--- a/src/common/nuclidePeakLines.test.ts
+++ b/src/common/nuclidePeakLines.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { buildNuclidePeakLines } from './nuclidePeakLines';
+import type { Nuclide } from './strahlenschutz';
+
+const NUCLIDES_FIXTURE: Nuclide[] = [
+  { name: 'Cs-137', gamma: 92, peaks: [661.7] },
+  { name: 'Co-60', gamma: 351, peaks: [1173.2, 1332.5] },
+  { name: 'Sr-90', gamma: 6 }, // no peaks
+];
+
+const PALETTE = ['#111', '#222', '#333'];
+
+describe('buildNuclidePeakLines', () => {
+  it('returns empty array for empty selection', () => {
+    expect(buildNuclidePeakLines([], NUCLIDES_FIXTURE, PALETTE)).toEqual([]);
+  });
+
+  it('builds one line per peak for a selected nuclide', () => {
+    const lines = buildNuclidePeakLines(['Co-60'], NUCLIDES_FIXTURE, PALETTE);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({
+      energy: 1173.2,
+      label: 'Co-60 (1173.2 keV)',
+      color: '#111',
+    });
+    expect(lines[1]).toMatchObject({
+      energy: 1332.5,
+      label: 'Co-60 (1332.5 keV)',
+      color: '#111',
+    });
+  });
+
+  it('assigns a distinct color per nuclide based on selection order', () => {
+    const lines = buildNuclidePeakLines(
+      ['Cs-137', 'Co-60'],
+      NUCLIDES_FIXTURE,
+      PALETTE
+    );
+    const cs = lines.filter((l) => l.label.startsWith('Cs-137'));
+    const co = lines.filter((l) => l.label.startsWith('Co-60'));
+    expect(cs[0].color).toBe('#111');
+    expect(co[0].color).toBe('#222');
+    expect(co[1].color).toBe('#222');
+  });
+
+  it('ignores unknown nuclide names', () => {
+    const lines = buildNuclidePeakLines(
+      ['Does-Not-Exist', 'Cs-137'],
+      NUCLIDES_FIXTURE,
+      PALETTE
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0].label).toBe('Cs-137 (661.7 keV)');
+    // Palette index must still follow the selection order → second slot
+    expect(lines[0].color).toBe('#222');
+  });
+
+  it('skips nuclides without peaks', () => {
+    const lines = buildNuclidePeakLines(['Sr-90'], NUCLIDES_FIXTURE, PALETTE);
+    expect(lines).toEqual([]);
+  });
+
+  it('produces stable, unique keys per line', () => {
+    const lines = buildNuclidePeakLines(
+      ['Cs-137', 'Co-60'],
+      NUCLIDES_FIXTURE,
+      PALETTE
+    );
+    const keys = lines.map((l) => l.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('cycles through the palette when more nuclides than colors', () => {
+    const lines = buildNuclidePeakLines(
+      ['Cs-137', 'Co-60', 'Cs-137'],
+      NUCLIDES_FIXTURE,
+      ['#aaa', '#bbb']
+    );
+    const firstCs = lines.find((l) => l.key.startsWith('0:'));
+    const thirdCs = lines.find((l) => l.key.startsWith('2:'));
+    expect(firstCs?.color).toBe('#aaa');
+    expect(thirdCs?.color).toBe('#aaa');
+  });
+});

--- a/src/common/nuclidePeakLines.ts
+++ b/src/common/nuclidePeakLines.ts
@@ -1,0 +1,37 @@
+import type { Nuclide } from './strahlenschutz';
+
+export interface NuclidePeakLine {
+  key: string;
+  label: string;
+  energy: number;
+  color: string;
+}
+
+/**
+ * Build reference-line descriptors for the peaks of a user-selected subset of
+ * nuclides. Each selected nuclide gets its own color from the palette (cycling
+ * by selection order, not by nuclide identity, so duplicate selections or
+ * unknown names don't shift the palette index for later entries).
+ */
+export function buildNuclidePeakLines(
+  selectedNames: string[],
+  nuclides: Nuclide[],
+  palette: string[]
+): NuclidePeakLine[] {
+  if (palette.length === 0) return [];
+  const lines: NuclidePeakLine[] = [];
+  selectedNames.forEach((name, idx) => {
+    const nuclide = nuclides.find((n) => n.name === name);
+    if (!nuclide?.peaks?.length) return;
+    const color = palette[idx % palette.length];
+    for (const energy of nuclide.peaks) {
+      lines.push({
+        key: `${idx}:${name}:${energy}`,
+        label: `${name} (${energy} keV)`,
+        energy,
+        color,
+      });
+    }
+  });
+  return lines;
+}

--- a/src/common/spectrumIdentification.test.ts
+++ b/src/common/spectrumIdentification.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSpectrumIdentification } from './spectrumIdentification';
+
+describe('resolveSpectrumIdentification', () => {
+  it('returns source=none when nothing is identified', () => {
+    expect(resolveSpectrumIdentification(undefined, undefined)).toEqual({
+      displayName: null,
+      source: 'none',
+    });
+  });
+
+  it('returns the auto match when no manual assignment is present', () => {
+    expect(
+      resolveSpectrumIdentification(undefined, {
+        name: 'Cs-137',
+        confidence: 0.82,
+      })
+    ).toEqual({
+      displayName: 'Cs-137',
+      source: 'auto',
+      confidence: 0.82,
+    });
+  });
+
+  it('prefers the manual assignment over the auto match', () => {
+    expect(
+      resolveSpectrumIdentification('Co-60', {
+        name: 'Cs-137',
+        confidence: 0.4,
+      })
+    ).toEqual({
+      displayName: 'Co-60',
+      source: 'manual',
+      autoAlt: { name: 'Cs-137', confidence: 0.4 },
+    });
+  });
+
+  it('omits autoAlt when manual equals the auto match', () => {
+    expect(
+      resolveSpectrumIdentification('Cs-137', {
+        name: 'Cs-137',
+        confidence: 0.9,
+      })
+    ).toEqual({
+      displayName: 'Cs-137',
+      source: 'manual',
+    });
+  });
+
+  it('omits autoAlt when manual is set but no auto match exists', () => {
+    expect(resolveSpectrumIdentification('Sr-90', undefined)).toEqual({
+      displayName: 'Sr-90',
+      source: 'manual',
+    });
+  });
+
+  it('treats an empty manual string as not set', () => {
+    expect(
+      resolveSpectrumIdentification('', {
+        name: 'Cs-137',
+        confidence: 0.5,
+      })
+    ).toEqual({
+      displayName: 'Cs-137',
+      source: 'auto',
+      confidence: 0.5,
+    });
+  });
+});

--- a/src/common/spectrumIdentification.ts
+++ b/src/common/spectrumIdentification.ts
@@ -1,0 +1,42 @@
+export interface AutoMatch {
+  name: string;
+  confidence: number;
+}
+
+export type SpectrumIdentification =
+  | { displayName: null; source: 'none' }
+  | { displayName: string; source: 'auto'; confidence: number }
+  | {
+      displayName: string;
+      source: 'manual';
+      autoAlt?: AutoMatch;
+    };
+
+/**
+ * Resolve which nuclide to display for a spectrum. A manual assignment always
+ * wins over the auto match. If auto disagrees with the manual choice, it is
+ * surfaced as `autoAlt` so the user still sees the competing suggestion.
+ */
+export function resolveSpectrumIdentification(
+  manualNuclide: string | undefined,
+  autoMatch: AutoMatch | undefined
+): SpectrumIdentification {
+  if (manualNuclide && manualNuclide.length > 0) {
+    if (autoMatch && autoMatch.name !== manualNuclide) {
+      return {
+        displayName: manualNuclide,
+        source: 'manual',
+        autoAlt: autoMatch,
+      };
+    }
+    return { displayName: manualNuclide, source: 'manual' };
+  }
+  if (autoMatch) {
+    return {
+      displayName: autoMatch.name,
+      source: 'auto',
+      confidence: autoMatch.confidence,
+    };
+  }
+  return { displayName: null, source: 'none' };
+}

--- a/src/components/firebase/firestore.ts
+++ b/src/components/firebase/firestore.ts
@@ -213,6 +213,7 @@ export interface Spectrum extends FirecallItem {
   counts: number[];
   matchedNuclide?: string;
   matchedConfidence?: number;
+  manualNuclide?: string;
   description?: string;
 }
 

--- a/src/components/pages/EnergySpectrum.tsx
+++ b/src/components/pages/EnergySpectrum.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -42,6 +43,7 @@ import {
   type SpectrumData,
   type NuclideMatch,
 } from '../../common/spectrumParser';
+import { buildNuclidePeakLines } from '../../common/nuclidePeakLines';
 import {
   FIRECALL_COLLECTION_ID,
   Spectrum,
@@ -59,6 +61,22 @@ const SERIES_COLORS = [
   '#f57c00',
   '#7b1fa2',
   '#0288d1',
+];
+
+/**
+ * Palette for manually selected nuclide peak lines. Intentionally distinct from
+ * SERIES_COLORS (spectrum curves) and the red (#d32f2f) used for auto-matched
+ * peaks, so the three line sets stay visually separable.
+ */
+const SELECTED_PEAK_COLORS = [
+  '#00796b',
+  '#c2185b',
+  '#5d4037',
+  '#455a64',
+  '#512da8',
+  '#ef6c00',
+  '#2e7d32',
+  '#1565c0',
 ];
 
 interface LoadedSpectrum {
@@ -119,6 +137,9 @@ export default function EnergySpectrum() {
   const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
   const [logScale, setLogScale] = useState(false);
   const [editDialog, setEditDialog] = useState<EditDialogState | null>(null);
+  const [selectedNuclideNames, setSelectedNuclideNames] = useState<string[]>(
+    []
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const firecallId = useFirecallId();
@@ -287,6 +308,16 @@ export default function EnergySpectrum() {
     [deferredVisibleSpectra]
   );
 
+  const selectedPeakLines = useMemo(
+    () =>
+      buildNuclidePeakLines(
+        selectedNuclideNames,
+        MATCHABLE_NUCLIDES,
+        SELECTED_PEAK_COLORS
+      ),
+    [selectedNuclideNames]
+  );
+
   // Collect matched peak energies from visible spectra for reference lines
   const matchedPeakEnergies = useMemo(() => {
     const peakMap = new Map<string, number>(); // label -> energy keV
@@ -424,6 +455,42 @@ export default function EnergySpectrum() {
             <InfoOutlinedIcon />
           </IconButton>
         </Tooltip>
+        <Autocomplete
+          multiple
+          size="small"
+          options={MATCHABLE_NUCLIDES.map((n) => n.name)}
+          value={selectedNuclideNames}
+          onChange={(_, value) => setSelectedNuclideNames(value)}
+          sx={{ minWidth: 260, flex: 1 }}
+          renderValue={(value, getItemProps) =>
+            value.map((name, idx) => {
+              const color =
+                SELECTED_PEAK_COLORS[idx % SELECTED_PEAK_COLORS.length];
+              const { key, ...itemProps } = getItemProps({ index: idx });
+              return (
+                <Chip
+                  key={key}
+                  label={name}
+                  size="small"
+                  {...itemProps}
+                  sx={{
+                    borderLeft: `4px solid ${color}`,
+                    borderRadius: 1,
+                  }}
+                />
+              );
+            })
+          }
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Peaks von Nukliden einblenden"
+              placeholder={
+                selectedNuclideNames.length === 0 ? 'Nuklide wählen' : ''
+              }
+            />
+          )}
+        />
       </Box>
 
       {/* Identification Results */}
@@ -692,6 +759,23 @@ export default function EnergySpectrum() {
                 />
               )
             )}
+            {selectedPeakLines.map((line) => (
+              <ChartsReferenceLine
+                key={line.key}
+                x={line.energy}
+                label={line.label}
+                lineStyle={{
+                  stroke: line.color,
+                  strokeWidth: 1.5,
+                  strokeDasharray: '2 3',
+                }}
+                labelStyle={{
+                  fontSize: 10,
+                  fill: line.color,
+                  fontWeight: 'bold',
+                }}
+              />
+            ))}
           </LineChart>
         </Box>
       )}

--- a/src/components/pages/EnergySpectrum.tsx
+++ b/src/components/pages/EnergySpectrum.tsx
@@ -44,6 +44,7 @@ import {
   type NuclideMatch,
 } from '../../common/spectrumParser';
 import { buildNuclidePeakLines } from '../../common/nuclidePeakLines';
+import { resolveSpectrumIdentification } from '../../common/spectrumIdentification';
 import {
   FIRECALL_COLLECTION_ID,
   Spectrum,
@@ -86,6 +87,7 @@ interface LoadedSpectrum {
   matches: NuclideMatch[];
   visible: boolean;
   description?: string;
+  manualNuclide?: string;
 }
 
 /**
@@ -131,6 +133,7 @@ interface EditDialogState {
   firestoreId?: string;
   sampleName: string;
   description: string;
+  manualNuclide: string | null;
 }
 
 export default function EnergySpectrum() {
@@ -190,6 +193,7 @@ export default function EnergySpectrum() {
         matches,
         visible: !hiddenIds.has(id),
         description: saved.description,
+        manualNuclide: saved.manualNuclide,
       };
     });
   }, [savedSpectra, hiddenIds]);
@@ -270,6 +274,7 @@ export default function EnergySpectrum() {
         firestoreId: spectrum.firestoreId,
         sampleName: spectrum.data.sampleName || '',
         description: spectrum.description || '',
+        manualNuclide: spectrum.manualNuclide ?? null,
       });
     },
     []
@@ -286,6 +291,7 @@ export default function EnergySpectrum() {
         name: editDialog.sampleName,
         sampleName: editDialog.sampleName,
         description: editDialog.description,
+        manualNuclide: editDialog.manualNuclide ?? '',
       } as Spectrum);
     }
 
@@ -498,6 +504,18 @@ export default function EnergySpectrum() {
         <List dense>
           {allSpectra.map((s, idx) => {
             const topMatch = s.matches[0];
+            const identification = resolveSpectrumIdentification(
+              s.manualNuclide,
+              topMatch
+                ? { name: topMatch.nuclide.name, confidence: topMatch.confidence }
+                : undefined
+            );
+            const identNuclide = identification.displayName
+              ? NUCLIDES.find((n) => n.name === identification.displayName)
+              : undefined;
+            const dbLinks = identification.displayName
+              ? getNuclideDbLinks(identification.displayName)
+              : null;
             return (
               <ListItem
                 key={s.id}
@@ -575,64 +593,77 @@ export default function EnergySpectrum() {
                       >
                         {s.data.sampleName || 'Unbekannt'}
                       </Typography>
-                      {topMatch && (() => {
-                        const dbLinks = getNuclideDbLinks(topMatch.nuclide.name);
-                        return (
-                          <>
-                            <Chip
-                              label={`${topMatch.nuclide.name} (${Math.round(topMatch.confidence * 100)}%)`}
-                              color="success"
-                              size="small"
-                            />
-                            {topMatch.nuclide.url && (
-                              <Chip
-                                label="RadiaCode"
-                                size="small"
-                                variant="outlined"
-                                component="a"
-                                href={topMatch.nuclide.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                clickable
-                                onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                              />
-                            )}
-                            {dbLinks && (
-                              <>
-                                <Chip
-                                  label="IAEA"
-                                  size="small"
-                                  variant="outlined"
-                                  component="a"
-                                  href={dbLinks.iaea}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  clickable
-                                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                                />
-                                <Chip
-                                  label="NNDC"
-                                  size="small"
-                                  variant="outlined"
-                                  component="a"
-                                  href={dbLinks.nndc}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  clickable
-                                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                                />
-                              </>
-                            )}
-                          </>
-                        );
-                      })()}
-                      {!topMatch && (
+                      {identification.source === 'manual' && (
+                        <Chip
+                          label={`${identification.displayName} (manuell)`}
+                          color="primary"
+                          size="small"
+                        />
+                      )}
+                      {identification.source === 'auto' && (
+                        <Chip
+                          label={`${identification.displayName} (${Math.round(identification.confidence * 100)}%)`}
+                          color="success"
+                          size="small"
+                        />
+                      )}
+                      {identification.source === 'none' && (
                         <Chip
                           label="Nicht identifiziert"
                           color="warning"
                           size="small"
                         />
                       )}
+                      {identNuclide?.url && (
+                        <Chip
+                          label="RadiaCode"
+                          size="small"
+                          variant="outlined"
+                          component="a"
+                          href={identNuclide.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          clickable
+                          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                        />
+                      )}
+                      {dbLinks && (
+                        <>
+                          <Chip
+                            label="IAEA"
+                            size="small"
+                            variant="outlined"
+                            component="a"
+                            href={dbLinks.iaea}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            clickable
+                            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                          />
+                          <Chip
+                            label="NNDC"
+                            size="small"
+                            variant="outlined"
+                            component="a"
+                            href={dbLinks.nndc}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            clickable
+                            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                          />
+                        </>
+                      )}
+                      {identification.source === 'manual' &&
+                        identification.autoAlt && (
+                          <Chip
+                            label={`Auto: ${identification.autoAlt.name} (${Math.round(
+                              identification.autoAlt.confidence * 100
+                            )}%)`}
+                            size="small"
+                            variant="outlined"
+                            color="default"
+                          />
+                        )}
                     </Box>
                   }
                   secondary={
@@ -677,6 +708,25 @@ export default function EnergySpectrum() {
                 prev ? { ...prev, sampleName: e.target.value } : prev
               )
             }
+          />
+          <Autocomplete
+            options={NUCLIDES.map((n) => n.name)}
+            value={editDialog?.manualNuclide ?? null}
+            onChange={(_, value) =>
+              setEditDialog((prev) =>
+                prev ? { ...prev, manualNuclide: value } : prev
+              )
+            }
+            sx={{ mt: 1 }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                margin="dense"
+                label="Nuklid (manuell zugeordnet)"
+                placeholder="Leer lassen, um Auto-Erkennung zu nutzen"
+                helperText="Überschreibt die automatische Erkennung in der Liste."
+              />
+            )}
           />
           <TextField
             margin="dense"


### PR DESCRIPTION
## Zusammenfassung

Erweitert die Energiespektrum-Ansicht um zwei zusammenhängende Funktionen für die Strahlenschutz-Arbeit: Peaks beliebiger Nuklide aus der Bibliothek können als Orientierungslinien eingeblendet werden, und ein erkanntes Nuklid kann pro Messung manuell zugeordnet werden und überschreibt damit die automatische Peak-Erkennung.

## Änderungen

- Multi-Select über dem Chart: 0..n Nuklide aus `NUCLIDES` lassen sich auswählen; für jeden Peak erscheint eine vertikale, gepunktete Referenzlinie in einer eigenen Farbe pro Nuklid (deutlich abgesetzt von den roten Dashed-Linien der Auto-Erkennung).
- Neuer Helper `buildNuclidePeakLines()` (pure, getestet) liefert die Linien-Deskriptoren; 7 Vitest-Tests decken leere Auswahl, unbekannte Namen, Peaks-lose Nuklide, eindeutige Keys und Palette-Zyklus ab.
- `Spectrum.manualNuclide` zum Firestore-Typ hinzugefügt; der Update-Hook filtert leere Werte, sodass ein Löschen des Feldes das Attribut aus dem Dokument entfernt.
- Neuer Eintrag "Nuklid (manuell zugeordnet)" im Bearbeiten-Dialog (Autocomplete über die volle `NUCLIDES`-Liste).
- Neue Pure-Funktion `resolveSpectrumIdentification()` (6 Tests) priorisiert manuelle vor automatischer Zuordnung; weicht Auto ab, wird es als zusätzlicher Outline-Chip `Auto: X (Y%)` daneben angezeigt.
- Listenanzeige der Messungen zeigt bei manueller Zuordnung einen blauen `(manuell)`-Chip, sonst den bestehenden grünen Auto-Match-Chip mit Confidence; RadiaCode/IAEA/NNDC-Links folgen dem tatsächlich angezeigten Nuklid.

## Test plan

- [ ] `npm run check` lokal grün (tsc, lint, 563 Tests, build)
- [ ] Im Einsatz unter Schadstoff → Energiespektrum eine oder mehrere Messungen hochladen
- [ ] Über dem Chart ein Nuklid auswählen → vertikale farbige Linien erscheinen an jedem Peak
- [ ] Mehrere Nuklide auswählen → jedes Nuklid hat eine eigene Farbe; die Chips zeigen denselben Farbakzent links
- [ ] Eine Messung bearbeiten, "Nuklid (manuell zugeordnet)" setzen → Liste zeigt `(manuell)`-Chip in blau; bei abweichendem Auto-Match erscheint zusätzlich `Auto: X (Y%)`
- [ ] Manuelles Nuklid wieder leeren → Auto-Match wird wieder primär angezeigt
- [ ] RadiaCode/IAEA/NNDC-Links der Messung zeigen auf das manuell gewählte Nuklid

🤖 Generated with [Claude Code](https://claude.com/claude-code)