### PR TITLE
feat(android): release workflow with Play Store upload

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,6 +1,10 @@
 name: "Android Release"
 
 on:
+  # TEMPORÄR: für initiales Testen auf dem Feature-Branch.
+  # VOR DEM MERGE IN MAIN ENTFERNEN.
+  push:
+    branches: [feat/android-release-workflow]
   release:
     types: [ published ]
   workflow_dispatch:
@@ -34,7 +38,7 @@ jobs:
       - name: Determine versionCode, versionName, track
         id: version
         env:
-          ALPHA: ${{ inputs.alpha }}
+          ALPHA: ${{ inputs.alpha || '0' }}
         run: |
           set -euo pipefail
           VERSION_CODE=$(git rev-list --count HEAD)

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,127 @@
+name: "Android Release"
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      alpha:
+        description: "Alpha-Nummer (für manuellen Build, hängt -alpha<N> an den letzten Tag)"
+        required: true
+        default: "0"
+
+concurrency:
+  group: android-release-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: "Build & Publish AAB"
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # WIF
+      contents: write # GitHub Release Asset upload
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # für git rev-list / git describe
+
+      - name: Determine versionCode, versionName, track
+        id: version
+        env:
+          ALPHA: ${{ inputs.alpha }}
+        run: |
+          set -euo pipefail
+          VERSION_CODE=$(git rev-list --count HEAD)
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            VERSION_NAME="${GITHUB_REF_NAME#v}"
+            TRACK="production"
+          else
+            if ! [[ "${ALPHA}" =~ ^[0-9]+$ ]]; then
+              echo "Invalid alpha input: ${ALPHA}" >&2
+              exit 1
+            fi
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match='v*')
+            VERSION_NAME="${LATEST_TAG#v}-alpha${ALPHA}"
+            TRACK="internal"
+          fi
+          {
+            echo "VERSION_CODE=${VERSION_CODE}"
+            echo "VERSION_NAME=${VERSION_NAME}"
+            echo "TRACK=${TRACK}"
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: capacitor/package-lock.json
+
+      - name: Install Capacitor dependencies
+        working-directory: capacitor
+        run: npm ci
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "21"
+          cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Authenticate to Google (WIF)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.PLAY_UPLOAD_SA_EMAIL }}
+
+      - name: Decode keystore + write keystore.properties
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          echo "${KEYSTORE_BASE64}" | base64 -d > capacitor/android/release.keystore
+          umask 077
+          {
+            echo "storeFile=release.keystore"
+            echo "storePassword=${KEYSTORE_PASSWORD}"
+            echo "keyAlias=ffn-einsatzkarte"
+            echo "keyPassword=${KEY_PASSWORD}"
+          } > capacitor/android/keystore.properties
+
+      - name: Capacitor sync
+        working-directory: capacitor
+        run: npx cap sync android
+
+      - name: Build & publish bundle to Play Store
+        working-directory: capacitor/android
+        env:
+          VERSION_CODE: ${{ steps.version.outputs.VERSION_CODE }}
+          VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
+          TRACK: ${{ steps.version.outputs.TRACK }}
+        run: |
+          ./gradlew publishBundle \
+            "-PappVersionCode=${VERSION_CODE}" \
+            "-PappVersionName=${VERSION_NAME}" \
+            "--track=${TRACK}"
+
+      - name: Attach AAB to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: capacitor/android/app/build/outputs/bundle/release/app-release.aab
+
+      - name: Cleanup keystore
+        if: always()
+        run: |
+          rm -f capacitor/android/release.keystore capacitor/android/keystore.properties

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -82,10 +82,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Authenticate to Google (WIF)
+        id: auth
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.PLAY_UPLOAD_SA_EMAIL }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/androidpublisher
 
       - name: Decode keystore + write keystore.properties
         env:
@@ -107,17 +110,70 @@ jobs:
         working-directory: capacitor
         run: npx cap sync android
 
-      - name: Build & publish bundle to Play Store
+      - name: Build AAB
         working-directory: capacitor/android
         env:
           VERSION_CODE: ${{ steps.version.outputs.VERSION_CODE }}
           VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
+        run: |
+          ./gradlew bundleRelease \
+            "-PappVersionCode=${VERSION_CODE}" \
+            "-PappVersionName=${VERSION_NAME}"
+
+      - name: Upload AAB to Play Store
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          PACKAGE_NAME: at.ffnd.einsatzkarte
+          AAB_PATH: capacitor/android/app/build/outputs/bundle/release/app-release.aab
+          VERSION_CODE: ${{ steps.version.outputs.VERSION_CODE }}
+          VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
           TRACK: ${{ steps.version.outputs.TRACK }}
         run: |
-          ./gradlew publishBundle \
-            "-PappVersionCode=${VERSION_CODE}" \
-            "-PappVersionName=${VERSION_NAME}" \
-            "--track=${TRACK}"
+          set -euo pipefail
+          API="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
+          UPLOAD_API="https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/${PACKAGE_NAME}"
+
+          gcall() {
+            local resp_file
+            resp_file=$(mktemp)
+            local code
+            code=$(curl -sS -o "${resp_file}" -w "%{http_code}" "$@")
+            if [[ ! "${code}" =~ ^2[0-9]{2}$ ]]; then
+              echo "HTTP ${code} from $*" >&2
+              cat "${resp_file}" >&2
+              rm -f "${resp_file}"
+              exit 1
+            fi
+            cat "${resp_file}"
+            rm -f "${resp_file}"
+          }
+
+          echo "==> Creating edit"
+          EDIT_ID=$(gcall -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "${API}/edits" | jq -r '.id')
+          echo "Edit ID: ${EDIT_ID}"
+
+          echo "==> Uploading AAB ($(du -h "${AAB_PATH}" | cut -f1))"
+          UPLOADED_VC=$(gcall -X POST \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary "@${AAB_PATH}" \
+            "${UPLOAD_API}/edits/${EDIT_ID}/bundles?uploadType=media" | jq -r '.versionCode')
+          echo "Uploaded versionCode: ${UPLOADED_VC} (expected ${VERSION_CODE})"
+
+          echo "==> Assigning to track ${TRACK}"
+          TRACK_BODY=$(jq -nc \
+            --arg name "${VERSION_NAME}" \
+            --arg vc "${UPLOADED_VC}" \
+            '{releases: [{name: $name, versionCodes: [$vc], status: "completed"}]}')
+          gcall -X PATCH \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "${TRACK_BODY}" \
+            "${API}/edits/${EDIT_ID}/tracks/${TRACK}" >/dev/null
+
+          echo "==> Committing edit"
+          gcall -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "${API}/edits/${EDIT_ID}:commit" >/dev/null
+          echo "Done — versionName=${VERSION_NAME} versionCode=${UPLOADED_VC} track=${TRACK}"
 
       - name: Attach AAB to GitHub Release
         if: github.event_name == 'release'

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,10 +1,6 @@
 name: "Android Release"
 
 on:
-  # TEMPORÄR: für initiales Testen auf dem Feature-Branch.
-  # VOR DEM MERGE IN MAIN ENTFERNEN.
-  push:
-    branches: [feat/android-release-workflow]
   release:
     types: [ published ]
   workflow_dispatch:

--- a/capacitor/.gitignore
+++ b/capacitor/.gitignore
@@ -7,4 +7,5 @@ android/app/release/
 android/app/debug/
 *.keystore
 !debug.keystore
+android/keystore.properties
 .kotlin/sessions

--- a/capacitor/android/app/build.gradle
+++ b/capacitor/android/app/build.gradle
@@ -1,5 +1,15 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.github.triplet.play'
+
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
+def appVersionCode = (project.findProperty('appVersionCode') ?: 2) as Integer
+def appVersionName = project.findProperty('appVersionName') ?: '2.49.0-alpha1'
 
 android {
     namespace = "at.ffnd.einsatzkarte"
@@ -11,8 +21,8 @@ android {
         applicationId "at.ffnd.einsatzkarte"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode appVersionCode
+        versionName appVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -20,10 +30,23 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                storeFile rootProject.file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (keystorePropertiesFile.exists()) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 }

--- a/capacitor/android/app/build.gradle
+++ b/capacitor/android/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'com.github.triplet.play'
 
 def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
@@ -79,17 +78,6 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
-}
-
-// Triple-T play-publisher 3.x kennt kein automatisches ADC-Fallback,
-// daher den GOOGLE_APPLICATION_CREDENTIALS-Pfad (gesetzt von
-// google-github-actions/auth) manuell durchreichen. Ohne env var
-// (lokal) bleibt die Config leer und publishBundle ist nicht nutzbar.
-def gappCreds = System.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-if (gappCreds != null && file(gappCreds).exists()) {
-    play {
-        serviceAccountCredentials.set(file(gappCreds))
-    }
 }
 
 apply from: 'capacitor.build.gradle'

--- a/capacitor/android/app/build.gradle
+++ b/capacitor/android/app/build.gradle
@@ -81,6 +81,17 @@ dependencies {
     implementation project(':capacitor-cordova-android-plugins')
 }
 
+// Triple-T play-publisher 3.x kennt kein automatisches ADC-Fallback,
+// daher den GOOGLE_APPLICATION_CREDENTIALS-Pfad (gesetzt von
+// google-github-actions/auth) manuell durchreichen. Ohne env var
+// (lokal) bleibt die Config leer und publishBundle ist nicht nutzbar.
+def gappCreds = System.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+if (gappCreds != null && file(gappCreds).exists()) {
+    play {
+        serviceAccountCredentials.set(file(gappCreds))
+    }
+}
+
 apply from: 'capacitor.build.gradle'
 
 try {

--- a/capacitor/android/build.gradle
+++ b/capacitor/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.github.triplet.gradle:play-publisher:4.0.0'
+        classpath 'com.github.triplet.gradle:play-publisher:3.13.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/capacitor/android/build.gradle
+++ b/capacitor/android/build.gradle
@@ -11,7 +11,6 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.github.triplet.gradle:play-publisher:3.13.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/capacitor/android/build.gradle
+++ b/capacitor/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'com.github.triplet.gradle:play-publisher:4.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/capacitor/build.sh
+++ b/capacitor/build.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Build the Android APK for sideloading.
+# Build the Android APK or AAB.
 #
 # Usage:
-#   ./build.sh            # debug build (default)
-#   ./build.sh release    # release build (needs signing config in android/app)
+#   ./build.sh            # debug APK (default, for sideloading)
+#   ./build.sh release    # release APK (needs signing config in android/app)
+#   ./build.sh bundle     # release AAB for Google Play (needs signing config)
 #
-# The produced APK path is printed at the end.
+# The produced artifact path is printed at the end.
 
 set -euo pipefail
 
@@ -17,14 +18,21 @@ BUILD_TYPE="${1:-debug}"
 case "$BUILD_TYPE" in
   debug)
     GRADLE_TASK="assembleDebug"
-    APK_PATH="android/app/build/outputs/apk/debug/app-debug.apk"
+    ARTIFACT_PATH="android/app/build/outputs/apk/debug/app-debug.apk"
+    ARTIFACT_LABEL="APK"
     ;;
   release)
     GRADLE_TASK="assembleRelease"
-    APK_PATH="android/app/build/outputs/apk/release/app-release.apk"
+    ARTIFACT_PATH="android/app/build/outputs/apk/release/app-release.apk"
+    ARTIFACT_LABEL="APK"
+    ;;
+  bundle)
+    GRADLE_TASK="bundleRelease"
+    ARTIFACT_PATH="android/app/build/outputs/bundle/release/app-release.aab"
+    ARTIFACT_LABEL="AAB"
     ;;
   *)
-    echo "Unknown build type: $BUILD_TYPE (use 'debug' or 'release')" >&2
+    echo "Unknown build type: $BUILD_TYPE (use 'debug', 'release', or 'bundle')" >&2
     exit 1
     ;;
 esac
@@ -37,11 +45,15 @@ cd android
 ./gradlew "$GRADLE_TASK"
 cd "$SCRIPT_DIR"
 
-if [[ -f "$APK_PATH" ]]; then
+if [[ -f "$ARTIFACT_PATH" ]]; then
   echo ""
-  echo "APK built: $APK_PATH"
-  echo "Sideload: adb install -r \"$APK_PATH\""
+  echo "$ARTIFACT_LABEL built: $ARTIFACT_PATH"
+  if [[ "$ARTIFACT_LABEL" == "APK" ]]; then
+    echo "Sideload: adb install -r \"$ARTIFACT_PATH\""
+  else
+    echo "Upload to Google Play Console: https://play.google.com/console"
+  fi
 else
-  echo "Build finished but expected APK not found at: $APK_PATH" >&2
+  echo "Build finished but expected $ARTIFACT_LABEL not found at: $ARTIFACT_PATH" >&2
   exit 1
 fi

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check": "npx tsc --noEmit && npx eslint && vitest run && next build --webpack",
     "build:android": "capacitor/build.sh",
     "build:android:release": "capacitor/build.sh release",
+    "build:android:bundle": "capacitor/build.sh bundle",
     "install:android": "npm run build:android && adb install -r capacitor/android/app/build/outputs/apk/debug/app-debug.apk",
     "install:android:release": "npm run build:android:release && adb install -r capacitor/android/app/build/outputs/apk/release/app-release.apk",
     "logs:android": "adb logcat -v time Capacitor:V Capacitor/Plugin:V chromium:V CapacitorBluetoothLe:V RadiacodeFg:V RadiacodeBT:V RadiacodeBTIo:V DataBufDecoder:* RadiacodeTrack:* Firestore:W Firestore:E FirebaseAuth:W *:S"

--- a/src/app/blaulicht-sms/actions.ts
+++ b/src/app/blaulicht-sms/actions.ts
@@ -94,7 +94,14 @@ async function loadCredentials(
 export async function getBlaulichtSmsAlarms(
   groupId: string
 ): Promise<BlaulichtSmsAlarm[]> {
-  await actionUserRequired();
+  const session = await actionUserRequired();
+
+  const userGroups = session.user.groups ?? [];
+  if (!session.user.isAdmin && !userGroups.includes(groupId)) {
+    // User is not a member of this group — refuse to load alarms.
+    // Return an empty list (instead of throwing) so the dialog stays usable.
+    return [];
+  }
 
   const creds = await loadCredentials(groupId);
   if (!creds) return [];

--- a/src/app/blaulicht-sms/credentialsActions.ts
+++ b/src/app/blaulicht-sms/credentialsActions.ts
@@ -86,11 +86,18 @@ export async function hasBlaulichtsmsConfig(
   return doc.exists;
 }
 
-// User-accessible: returns group IDs that have credentials configured.
+// User-accessible: returns group IDs that have credentials configured AND
+// the calling user is a member of. Admins receive the full list (no filter).
 // Used by EinsatzDialog to decide whether to show the alarm dropdown.
 export async function getGroupsWithBlaulichtsmsConfig(): Promise<string[]> {
-  await actionUserRequired();
+  const session = await actionUserRequired();
   const { appendLegacyGroup } = await import('./legacyGroup');
+  const { filterGroupsByMembership } = await import('./groupFilter');
   const snapshot = await firestore.collection(COLLECTION).get();
-  return appendLegacyGroup(snapshot.docs.map((d) => d.id));
+  const all = appendLegacyGroup(snapshot.docs.map((d) => d.id));
+  return filterGroupsByMembership(
+    all,
+    session.user.groups ?? [],
+    session.user.isAdmin,
+  );
 }

--- a/src/app/blaulicht-sms/groupFilter.test.ts
+++ b/src/app/blaulicht-sms/groupFilter.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { filterGroupsByMembership } from './groupFilter';
+
+describe('filterGroupsByMembership', () => {
+  it('returns all groups for admin even if not member', () => {
+    expect(filterGroupsByMembership(['ffnd', 'test'], [], true)).toEqual([
+      'ffnd',
+      'test',
+    ]);
+  });
+
+  it('returns only groups the non-admin user is member of', () => {
+    expect(
+      filterGroupsByMembership(['ffnd', 'test', 'other'], ['test'], false),
+    ).toEqual(['test']);
+  });
+
+  it('returns empty when non-admin user has no matching groups', () => {
+    expect(filterGroupsByMembership(['ffnd'], ['other'], false)).toEqual([]);
+  });
+
+  it('returns empty when non-admin user has no groups', () => {
+    expect(filterGroupsByMembership(['ffnd'], [], false)).toEqual([]);
+  });
+
+  it('preserves order of configured groups', () => {
+    expect(
+      filterGroupsByMembership(['z', 'a', 'm'], ['a', 'm', 'z'], false),
+    ).toEqual(['z', 'a', 'm']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = ['ffnd', 'test'];
+    filterGroupsByMembership(input, ['test'], false);
+    expect(input).toEqual(['ffnd', 'test']);
+  });
+
+  it('returns a copy for admin (no shared reference)', () => {
+    const input = ['ffnd'];
+    const result = filterGroupsByMembership(input, [], true);
+    expect(result).not.toBe(input);
+    expect(result).toEqual(input);
+  });
+});

--- a/src/app/blaulicht-sms/groupFilter.ts
+++ b/src/app/blaulicht-sms/groupFilter.ts
@@ -1,0 +1,13 @@
+/**
+ * Filters BlaulichtSMS-configured groups by user membership.
+ * Admins bypass the filter and see every configured group; other users
+ * only see groups they are a member of.
+ */
+export function filterGroupsByMembership(
+  configuredGroups: string[],
+  userGroups: string[],
+  isAdmin: boolean,
+): string[] {
+  if (isAdmin) return [...configuredGroups];
+  return configuredGroups.filter((g) => userGroups.includes(g));
+}

--- a/src/app/groups/groupHelpers.ts
+++ b/src/app/groups/groupHelpers.ts
@@ -5,6 +5,7 @@ import {
 } from '../../components/firebase/firestore';
 import { firestore } from '../../server/firebase/admin';
 import { Group, KNOWN_GROUPS } from './groupTypes';
+import { sortGroupsForUser } from './groupSort';
 
 // Re-export for backwards compatibility
 export type { Group };
@@ -27,7 +28,6 @@ export async function getMyGroups(userId: string): Promise<Group[]> {
         await firestore.collection(USER_COLLECTION_ID).doc(userId).get()
       ).data() as UserRecordExtended
     ).groups || [];
-  return allGropus
-    .filter((g) => g.id && myGroupIds.includes(g.id))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const mine = allGropus.filter((g) => g.id && myGroupIds.includes(g.id));
+  return sortGroupsForUser(mine);
 }

--- a/src/app/groups/groupSort.test.ts
+++ b/src/app/groups/groupSort.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { sortGroupsForUser, ALL_USERS_GROUP_ID } from './groupSort';
+import type { Group } from './groupTypes';
+
+const g = (id: string, name: string): Group => ({ id, name });
+
+describe('sortGroupsForUser', () => {
+  it('puts allUsers at the end of an alphabetically sorted list', () => {
+    const result = sortGroupsForUser([
+      g(ALL_USERS_GROUP_ID, 'Alle Benutzer'),
+      g('ffnd', 'FF Neusiedl am See'),
+      g('test', 'Test'),
+    ]);
+    expect(result.map((x) => x.id)).toEqual(['ffnd', 'test', ALL_USERS_GROUP_ID]);
+  });
+
+  it('preserves alphabetical order among non-allUsers groups', () => {
+    const result = sortGroupsForUser([
+      g('z', 'Zulu'),
+      g('a', 'Alpha'),
+      g('m', 'Mike'),
+    ]);
+    expect(result.map((x) => x.id)).toEqual(['a', 'm', 'z']);
+  });
+
+  it('handles a list without allUsers', () => {
+    const result = sortGroupsForUser([g('b', 'Bravo'), g('a', 'Alpha')]);
+    expect(result.map((x) => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('handles a list containing only allUsers', () => {
+    const result = sortGroupsForUser([g(ALL_USERS_GROUP_ID, 'Alle Benutzer')]);
+    expect(result.map((x) => x.id)).toEqual([ALL_USERS_GROUP_ID]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      g(ALL_USERS_GROUP_ID, 'Alle Benutzer'),
+      g('ffnd', 'FF Neusiedl am See'),
+    ];
+    sortGroupsForUser(input);
+    expect(input.map((x) => x.id)).toEqual([ALL_USERS_GROUP_ID, 'ffnd']);
+  });
+
+  it('uses locale-aware compare for German umlauts', () => {
+    const result = sortGroupsForUser([
+      g('z', 'Zulu'),
+      g('a', 'Älpler'),
+      g('b', 'Bravo'),
+    ]);
+    expect(result.map((x) => x.id)).toEqual(['a', 'b', 'z']);
+  });
+});

--- a/src/app/groups/groupSort.ts
+++ b/src/app/groups/groupSort.ts
@@ -1,0 +1,18 @@
+import type { Group } from './groupTypes';
+
+/**
+ * The catch-all "alle Benutzer" group is sorted to the end of every
+ * user-facing list. Every authorized user is in it, so listing it first
+ * (alphabetical "A...") would push the more specific groups out of view.
+ */
+export const ALL_USERS_GROUP_ID = 'allUsers';
+
+export function compareGroupsForUser(a: Group, b: Group): number {
+  if (a.id === ALL_USERS_GROUP_ID && b.id !== ALL_USERS_GROUP_ID) return 1;
+  if (b.id === ALL_USERS_GROUP_ID && a.id !== ALL_USERS_GROUP_ID) return -1;
+  return (a.name || '').localeCompare(b.name || '');
+}
+
+export function sortGroupsForUser(groups: Group[]): Group[] {
+  return [...groups].sort(compareGroupsForUser);
+}

--- a/src/components/FirecallItems/EinsatzDialog.tsx
+++ b/src/components/FirecallItems/EinsatzDialog.tsx
@@ -88,7 +88,8 @@ export default function EinsatzDialog({
     }));
   }, []);
 
-  // Load which groups have BlaulichtSMS credentials (once on dialog mount)
+  // Load which groups have BlaulichtSMS credentials (once on dialog mount).
+  // The server filters this list by the caller's group membership.
   useEffect(() => {
     getGroupsWithBlaulichtsmsConfig()
       .then(setConfiguredGroups)
@@ -96,6 +97,21 @@ export default function EinsatzDialog({
         console.error('Failed to load BlaulichtSMS configured groups:', err)
       );
   }, []);
+
+  // For new Einsätze: default the group to the first one the user is a
+  // member of as soon as `myGroups` is available. Avoids a hardcoded
+  // default that may not match the user's permissions.
+  useEffect(() => {
+    if (!isNewEinsatz) return;
+    if (einsatz.group) return;
+    if (myGroups.length === 0) return;
+    const defaultGroup = myGroups[0].id;
+    if (!defaultGroup) return;
+    setEinsatz((prev) =>
+      prev.group ? prev : { ...prev, group: defaultGroup },
+    );
+    setSelectedGroup((prev) => prev || defaultGroup);
+  }, [isNewEinsatz, einsatz.group, myGroups]);
 
   // Fetch alarms when selected group changes and has credentials
   useEffect(() => {
@@ -274,6 +290,16 @@ export default function EinsatzDialog({
             onChange={handleChange}
             required
           >
+            {einsatz.group &&
+              !myGroups.some((g) => g.id === einsatz.group) && (
+                <MenuItem
+                  key={`group-${einsatz.group}-readonly`}
+                  value={einsatz.group}
+                  disabled
+                >
+                  {einsatz.group} (keine Berechtigung)
+                </MenuItem>
+              )}
             {myGroups.map((group) => (
               <MenuItem key={`group-${group.id}`} value={group.id}>
                 {group.name}

--- a/src/components/FirecallItems/EinsatzDialog.tsx
+++ b/src/components/FirecallItems/EinsatzDialog.tsx
@@ -113,15 +113,26 @@ export default function EinsatzDialog({
     setSelectedGroup((prev) => prev || defaultGroup);
   }, [isNewEinsatz, einsatz.group, myGroups]);
 
-  // Fetch alarms when selected group changes and has credentials
+  // Fetch alarms when selected group changes and has credentials.
+  // Whenever no fresh alarm gets auto-applied (group has no credentials,
+  // or returned 0 alarms), clear any previously applied alarm data so the
+  // dialog never carries stale BlaulichtSMS info from a different group.
   useEffect(() => {
     const shouldFetch =
       selectedGroup && configuredGroups.includes(selectedGroup);
 
+    const clearStaleAlarmData = () => {
+      if (!isNewEinsatz) return;
+      setSelectedAlarmId('');
+      setEinsatz((prev) =>
+        prev.blaulichtSmsAlarmId ? resetEinsatzToManual(prev) : prev,
+      );
+    };
+
     const fetchAlarms = async () => {
       if (!shouldFetch) {
         setAlarms([]);
-        if (isNewEinsatz) setSelectedAlarmId('');
+        clearStaleAlarmData();
         return;
       }
       setAlarmsLoading(true);
@@ -132,9 +143,13 @@ export default function EinsatzDialog({
             new Date(b.alarmDate).getTime() - new Date(a.alarmDate).getTime()
         );
         setAlarms(sorted);
-        if (isNewEinsatz && sorted.length > 0) {
-          setSelectedAlarmId(sorted[0].alarmId);
-          applyAlarm(sorted[0]);
+        if (isNewEinsatz) {
+          if (sorted.length > 0) {
+            setSelectedAlarmId(sorted[0].alarmId);
+            applyAlarm(sorted[0]);
+          } else {
+            clearStaleAlarmData();
+          }
         }
       } catch (err) {
         console.error('Failed to fetch BlaulichtSMS alarms:', err);

--- a/src/components/FirecallItems/einsatzDefaults.test.ts
+++ b/src/components/FirecallItems/einsatzDefaults.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   createDefaultEinsatz,
   DEFAULT_EINSATZ_FW,
-  DEFAULT_EINSATZ_GROUP,
   resetEinsatzToManual,
 } from './einsatzDefaults';
 import { Firecall } from '../firebase/firestore';
@@ -12,7 +11,9 @@ describe('createDefaultEinsatz', () => {
     const now = new Date('2026-04-18T12:34:56.000Z');
     const einsatz = createDefaultEinsatz(now);
 
-    expect(einsatz.group).toBe(DEFAULT_EINSATZ_GROUP);
+    // group is unset by default — the dialog assigns it from the
+    // user's group memberships so we never default to a foreign group.
+    expect(einsatz.group).toBeUndefined();
     expect(einsatz.fw).toBe(DEFAULT_EINSATZ_FW);
     expect(einsatz.description).toBe('');
     expect(einsatz.deleted).toBe(false);

--- a/src/components/FirecallItems/einsatzDefaults.ts
+++ b/src/components/FirecallItems/einsatzDefaults.ts
@@ -1,16 +1,17 @@
 import { formatTimestamp } from '../../common/time-format';
 import { Firecall } from '../firebase/firestore';
 
-export const DEFAULT_EINSATZ_GROUP = 'ffnd';
 export const DEFAULT_EINSATZ_FW = 'Neusiedl am See';
 
 export function createDefaultEinsatz(
   now: Date = new Date(),
   overrides: Partial<Firecall> = {},
 ): Firecall {
+  // group is intentionally left unset here. The dialog will assign it
+  // dynamically based on the logged-in user's group memberships, so
+  // anonymous defaults can never leak credentials of an unrelated group.
   return {
     name: `Einsatz am ${formatTimestamp(now)}`,
-    group: DEFAULT_EINSATZ_GROUP,
     fw: DEFAULT_EINSATZ_FW,
     description: '',
     date: now.toISOString(),

--- a/src/components/Map/RadiacodeLiveWidget.test.tsx
+++ b/src/components/Map/RadiacodeLiveWidget.test.tsx
@@ -76,10 +76,12 @@ describe('RadiacodeLiveWidget', () => {
   it('shows cps', () => {
     renderWithMeasurement(
       <RadiacodeLiveWidget />,
-      { dosisleistung: 0.14, cps: 42, timestamp: 1 },
+      { dosisleistung: 0.14, cps: 42.5, timestamp: 1 },
     );
-    expect(screen.getByText(/42/)).toBeInTheDocument();
-    expect(screen.getByText(/cps/i)).toBeInTheDocument();
+    // Zahl + "cps" zusammen matchen, damit der stale-Age-Hinweis
+    // ("Letzte Messung vor …s") mit ggf. enthaltener Ziffernfolge "42"
+    // nicht ungewollt mitmatcht. Float wird mitberücksichtigt.
+    expect(screen.getByText(/42(\.\d+)?\s*cps/i)).toBeInTheDocument();
   });
 
   it('has green background for low dose (< 1 µSv/h)', () => {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,6 +50,8 @@ locals {
     "texttospeech.googleapis.com",
     "picker.googleapis.com",
     "firebasevertexai.googleapis.com",
+    "androidpublisher.googleapis.com",
+    "chromewebstore.googleapis.com",
   ]
 }
 resource "google_project_service" "apis" {


### PR DESCRIPTION
## Zusammenfassung

Dieser Branch fügt einen automatisierten Android-Release-Workflow hinzu, der Capacitor-Builds als signierte AABs zum Google Play Store via Workload Identity Federation hochlädt. Zusätzlich enthalten sind mehrere Bugfixes rund um BlaulichtSMS-Credentials, Gruppen-Handling und das Einsatz-Dialog.

## Änderungen

- **Android-Release-Pipeline** (`.github/workflows/android-release.yml`): Tag-getriggerter Workflow, signiert das AAB und lädt es per direktem Play-API-Upload (curl + WIF) hoch
- **Capacitor-Build-Anpassungen**: `build.sh` und `app/build.gradle` für CI-Signing und Versionierung erweitert
- **Terraform**: APIs für Android Play und Chrome Web Store enabled (`terraform/main.tf`)
- **BlaulichtSMS**: Alarm-Credentials werden jetzt strikt anhand der User-Gruppenmitgliedschaft gefiltert (neue `groupFilter`-Helper inkl. Tests)
- **Gruppen-Sortierung**: "Alle Benutzer" wird in user-facing Listen ans Ende sortiert (neue `groupSort`-Helper inkl. Tests)
- **EinsatzDialog**: Setzt veraltete BlaulichtSMS-Daten bei Gruppenwechsel zurück
- Kleinere Test-Stabilisierung (`RadiacodeLiveWidget`)

## Test plan

- [x] `npx tsc --noEmit` ohne Fehler
- [x] `npx eslint` ohne Warnings
- [x] `npx vitest run` (900 passed, 1 skipped)
- [x] `npx next build --webpack` erfolgreich
- [x] Tag-Release manuell triggern und Play-Store-Upload verifizieren
- [x] BlaulichtSMS-Alarmfreigabe je Gruppe in der Web-UI prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)