### PR TITLE
feat(android): publish releases to internal and production simultaneously

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -9,6 +9,11 @@ on:
         description: "Alpha-Nummer (für manuellen Build, hängt -alpha<N> an den letzten Tag)"
         required: true
         default: "0"
+      promote_to_production:
+        description: "Auch auf Production-Track veröffentlichen (Standard: nur Internal Testing)"
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: android-release-${{ github.event.release.tag_name || github.ref }}
@@ -31,16 +36,17 @@ jobs:
         with:
           fetch-depth: 0 # für git rev-list / git describe
 
-      - name: Determine versionCode, versionName, track
+      - name: Determine versionCode, versionName, tracks
         id: version
         env:
           ALPHA: ${{ inputs.alpha || '0' }}
+          PROMOTE_TO_PRODUCTION: ${{ inputs.promote_to_production || 'false' }}
         run: |
           set -euo pipefail
           VERSION_CODE=$(git rev-list --count HEAD)
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
             VERSION_NAME="${GITHUB_REF_NAME#v}"
-            TRACK="production"
+            TRACKS="internal production"
           else
             if ! [[ "${ALPHA}" =~ ^[0-9]+$ ]]; then
               echo "Invalid alpha input: ${ALPHA}" >&2
@@ -48,12 +54,16 @@ jobs:
             fi
             LATEST_TAG=$(git describe --tags --abbrev=0 --match='v*')
             VERSION_NAME="${LATEST_TAG#v}-alpha${ALPHA}"
-            TRACK="internal"
+            if [[ "${PROMOTE_TO_PRODUCTION}" == "true" ]]; then
+              TRACKS="internal production"
+            else
+              TRACKS="internal"
+            fi
           fi
           {
             echo "VERSION_CODE=${VERSION_CODE}"
             echo "VERSION_NAME=${VERSION_NAME}"
-            echo "TRACK=${TRACK}"
+            echo "TRACKS=${TRACKS}"
           } | tee -a "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
@@ -123,7 +133,7 @@ jobs:
           AAB_PATH: capacitor/android/app/build/outputs/bundle/release/app-release.aab
           VERSION_CODE: ${{ steps.version.outputs.VERSION_CODE }}
           VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
-          TRACK: ${{ steps.version.outputs.TRACK }}
+          TRACKS: ${{ steps.version.outputs.TRACKS }}
         run: |
           set -euo pipefail
           API="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
@@ -156,20 +166,22 @@ jobs:
             "${UPLOAD_API}/edits/${EDIT_ID}/bundles?uploadType=media" | jq -r '.versionCode')
           echo "Uploaded versionCode: ${UPLOADED_VC} (expected ${VERSION_CODE})"
 
-          echo "==> Assigning to track ${TRACK}"
           TRACK_BODY=$(jq -nc \
             --arg name "${VERSION_NAME}" \
             --arg vc "${UPLOADED_VC}" \
             '{releases: [{name: $name, versionCodes: [$vc], status: "completed"}]}')
-          gcall -X PATCH \
-            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "${TRACK_BODY}" \
-            "${API}/edits/${EDIT_ID}/tracks/${TRACK}" >/dev/null
+          for TRACK in ${TRACKS}; do
+            echo "==> Assigning to track ${TRACK}"
+            gcall -X PATCH \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "${TRACK_BODY}" \
+              "${API}/edits/${EDIT_ID}/tracks/${TRACK}" >/dev/null
+          done
 
           echo "==> Committing edit"
           gcall -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "${API}/edits/${EDIT_ID}:commit" >/dev/null
-          echo "Done — versionName=${VERSION_NAME} versionCode=${UPLOADED_VC} track=${TRACK}"
+          echo "Done — versionName=${VERSION_NAME} versionCode=${UPLOADED_VC} tracks=${TRACKS}"
 
       - name: Attach AAB to GitHub Release
         if: github.event_name == 'release'


### PR DESCRIPTION
## Zusammenfassung

Bei einem GitHub-Release wird die Android-App jetzt in einem einzigen Play-Store-Edit gleichzeitig sowohl auf den **Internal Testing**- als auch den **Production**-Track veröffentlicht. Damit erhalten interne Tester bei jedem Release automatisch die aktuelle Version und bleiben nicht auf einer alten Alpha hängen.

Für manuelle `workflow_dispatch`-Builds gibt es einen neuen optionalen Boolean-Input `promote_to_production` (Default `false`), mit dem ein Alpha-Build wahlweise auch auf Production veröffentlicht werden kann.

## Änderungen

- Neuer Workflow-Input `promote_to_production` (Boolean, Default `false`) für `workflow_dispatch`
- Output `TRACK` (singular) → `TRACKS` (space-separierte Liste)
  - `release` Event → `internal production` (immer beide)
  - `workflow_dispatch` mit `promote_to_production=true` → `internal production`
  - `workflow_dispatch` ohne Flag (Default) → `internal`
- Upload-Schritt weist den Release in einem einzigen Edit per `for`-Schleife allen Tracks zu, dann ein einziger `:commit` → atomar, beide Tracks gehen gleichzeitig live

## Test plan

- [ ] Manueller `workflow_dispatch`-Lauf ohne `promote_to_production` veröffentlicht ausschließlich auf Internal Testing
- [ ] Manueller `workflow_dispatch`-Lauf mit `promote_to_production=true` veröffentlicht auf beide Tracks
- [ ] Echter GitHub-Release (Tag `vX.Y.Z`) veröffentlicht in einem Play-Edit gleichzeitig auf Internal Testing und Production
- [ ] Im Play Console wird derselbe `versionCode`/`versionName` auf beiden Tracks aktiv

🤖 Generated with [Claude Code](https://claude.com/claude-code)