### PR TITLE
feat(crashlytics): integrate Firebase Crashlytics + error resilience

### DIFF
--- a/capacitor/android/app/build.gradle
+++ b/capacitor/android/app/build.gradle
@@ -74,6 +74,9 @@ dependencies {
     implementation platform("com.google.firebase:firebase-bom:33.3.0")
     implementation "com.google.firebase:firebase-firestore-ktx"
     implementation "com.google.firebase:firebase-auth-ktx"
+    // Firebase Crashlytics — meldet native Android-Crashes an Firebase,
+    // damit Play-Store-Rejections nicht ohne Stack-Trace bleiben.
+    implementation "com.google.firebase:firebase-crashlytics-ktx"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
@@ -86,7 +89,8 @@ try {
     def servicesJSON = file('google-services.json')
     if (servicesJSON.text) {
         apply plugin: 'com.google.gms.google-services'
+        apply plugin: 'com.google.firebase.crashlytics'
     }
 } catch(Exception e) {
-    logger.info("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
+    logger.info("google-services.json not found, google-services + crashlytics plugins not applied.")
 }

--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/MainActivity.java
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/MainActivity.java
@@ -7,10 +7,12 @@ import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.net.http.SslError;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
@@ -19,6 +21,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.view.Window;
 
+import androidx.annotation.RequiresApi;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.core.splashscreen.SplashScreen;
 import androidx.core.view.WindowCompat;
@@ -26,6 +29,7 @@ import androidx.core.view.WindowCompat;
 import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.BridgeWebViewClient;
 import com.getcapacitor.CapConfig;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.json.JSONObject;
 
@@ -123,6 +127,40 @@ public class MainActivity extends BridgeActivity {
                 }
                 handler.cancel();
                 showLoadErrorDialog(error.getUrl(), "SSL: " + describeSslError(error));
+            }
+
+            // onRenderProcessGone gibt es erst ab API 26 (Android 8.0). minSdk ist 24,
+            // daher zur Sicherheit per SDK_INT-Check absichern, auch wenn der Callback
+            // vor API 26 gar nicht aufgerufen werden kann.
+            @Override
+            @RequiresApi(Build.VERSION_CODES.O)
+            public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                    return super.onRenderProcessGone(view, detail);
+                }
+                Log.e(TAG, "WebView renderer process gone, didCrash=" + detail.didCrash());
+                try {
+                    FirebaseCrashlytics.getInstance().recordException(
+                        new RuntimeException("WebView renderer process gone (didCrash=" + detail.didCrash() + ")")
+                    );
+                } catch (Throwable t) {
+                    Log.w(TAG, "Failed to report renderer crash to Crashlytics", t);
+                }
+                // Android-Vertrag: tote WebView muss aus dem View-Tree entfernt und
+                // mit destroy() freigegeben werden, sonst kann ein späterer Zugriff
+                // einen IllegalStateException werfen.
+                try {
+                    android.view.ViewParent parent = view.getParent();
+                    if (parent instanceof android.view.ViewGroup) {
+                        ((android.view.ViewGroup) parent).removeView(view);
+                    }
+                    view.destroy();
+                } catch (Throwable t) {
+                    Log.w(TAG, "Failed to remove/destroy dead WebView", t);
+                }
+                Log.i(TAG, "Recreating activity after renderer crash");
+                recreate();
+                return true; // wir haben den Crash behandelt, App nicht killen
             }
         });
     }

--- a/capacitor/android/build.gradle
+++ b/capacitor/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.4'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@auth/core": "^0.41.2",
         "@capacitor-community/bluetooth-le": "^8.1.0",
         "@capacitor-firebase/authentication": "^8.2.0",
+        "@capacitor-firebase/crashlytics": "^8.2.0",
         "@capacitor/app": "^8.1.0",
         "@capacitor/core": "^8.3.1",
         "@capacitor/filesystem": "^8.1.2",
@@ -546,6 +547,30 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0",
         "firebase": "^12.6.0"
+      },
+      "peerDependenciesMeta": {
+        "firebase": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@capacitor-firebase/crashlytics": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor-firebase/crashlytics/-/crashlytics-8.2.0.tgz",
+      "integrity": "sha512-3unj3kfKgmQMMXpenv3vYF4GwPqJn0vABFwJVMet32vZl2Dn+7z5vf41G+kJLmV7vDLC40R7mMntpQGVZMQYaw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       },
       "peerDependenciesMeta": {
         "firebase": {
@@ -8671,6 +8696,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@auth/core": "^0.41.2",
     "@capacitor-community/bluetooth-le": "^8.1.0",
     "@capacitor-firebase/authentication": "^8.2.0",
+    "@capacitor-firebase/crashlytics": "^8.2.0",
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.1",
     "@capacitor/filesystem": "^8.1.2",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,6 +3,7 @@
 // see https://nextjs.org/docs/app/building-your-application/routing/error-handling#uncaught-exceptions
 
 import { useEffect } from 'react';
+import { recordError } from '../components/firebase/crashlytics';
 
 export default function Error({
   error,
@@ -12,21 +13,16 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
-    console.error('Failed to render: ', error);
+    void recordError(error, {
+      source: 'next-error-page',
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
   }, [error]);
 
   return (
     <div>
-      <h2>Something went wrong!</h2>
-      <button
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
-      >
-        Try again
-      </button>
+      <h2>Etwas ist schiefgelaufen</h2>
+      <button onClick={() => reset()}>Erneut versuchen</button>
     </div>
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect } from 'react';
+import { recordError } from '../components/firebase/crashlytics';
 
 // Error boundaries must be Client Components
 // see https://nextjs.org/docs/app/building-your-application/routing/error-handling#uncaught-exceptions
@@ -12,16 +13,18 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
-    console.error('Global Error: ', error);
+    void recordError(error, {
+      source: 'next-global-error',
+      ...(error.digest ? { digest: error.digest } : {}),
+    });
   }, [error]);
 
   return (
     // global-error must include html and body tags
-    <html>
+    <html lang="de">
       <body>
-        <h2>Something went wrong!</h2>
-        <button onClick={() => reset()}>Try again</button>
+        <h2>Etwas ist schiefgelaufen</h2>
+        <button onClick={() => reset()}>Erneut versuchen</button>
       </body>
     </html>
   );

--- a/src/components/firebase/FirebaseUserProvider.tsx
+++ b/src/components/firebase/FirebaseUserProvider.tsx
@@ -3,6 +3,7 @@
 import Alert from '@mui/material/Alert';
 import Snackbar from '@mui/material/Snackbar';
 import React, { createContext } from 'react';
+import useCrashlyticsUserSync from '../../hooks/useCrashlyticsUserSync';
 import useFirebaseLoginObserver, {
   LoginStatus,
 } from '../../hooks/useFirebaseLoginObserver';
@@ -28,6 +29,7 @@ export default function FirebaseUserProvider({
 }) {
   useFirebaseCustomTokenLogin();
   const authInfo = useFirebaseLoginObserver();
+  useCrashlyticsUserSync(authInfo.uid);
   return (
     <FirebaseLoginContext.Provider value={authInfo}>
       {children}

--- a/src/components/firebase/crashlytics.test.ts
+++ b/src/components/firebase/crashlytics.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const {
+  recordExceptionMock,
+  setCustomKeyMock,
+  setUserIdMock,
+  logMock,
+} = vi.hoisted(() => ({
+  recordExceptionMock: vi.fn(() => Promise.resolve()),
+  setCustomKeyMock: vi.fn(() => Promise.resolve()),
+  setUserIdMock: vi.fn(() => Promise.resolve()),
+  logMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@capacitor-firebase/crashlytics', () => ({
+  FirebaseCrashlytics: {
+    recordException: recordExceptionMock,
+    setCustomKey: setCustomKeyMock,
+    setUserId: setUserIdMock,
+    log: logMock,
+  },
+}));
+
+import {
+  recordError,
+  logCrashlyticsMessage,
+  setCrashlyticsUserId,
+} from './crashlytics';
+
+describe('crashlytics wrapper', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    recordExceptionMock.mockClear();
+    recordExceptionMock.mockImplementation(() => Promise.resolve());
+    setCustomKeyMock.mockClear();
+    setCustomKeyMock.mockImplementation(() => Promise.resolve());
+    setUserIdMock.mockClear();
+    setUserIdMock.mockImplementation(() => Promise.resolve());
+    logMock.mockClear();
+    logMock.mockImplementation(() => Promise.resolve());
+    consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('recordError', () => {
+    it('forwards an Error with message and structured stack frames', async () => {
+      const err = new Error('boom');
+      await recordError(err);
+
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      expect(recordExceptionMock).toHaveBeenCalledTimes(1);
+      const firstCall = recordExceptionMock.mock.calls[0] as unknown as [
+        {
+          message: string;
+          stacktrace?: Array<{
+            fileName?: string;
+            functionName?: string;
+            lineNumber?: number;
+            columnNumber?: number;
+          }>;
+        },
+      ];
+      const args = firstCall[0];
+      expect(args.message).toBe('boom');
+      expect(args.stacktrace).toBeTruthy();
+      expect(Array.isArray(args.stacktrace)).toBe(true);
+      // At least one parsed frame should have a numeric line number — proves we
+      // parsed structured fields rather than dumping the raw line into functionName.
+      const hasStructured = args.stacktrace?.some(
+        (f) => typeof f.lineNumber === 'number' && !Number.isNaN(f.lineNumber),
+      );
+      expect(hasStructured).toBe(true);
+    });
+
+    it('accepts a plain string error', async () => {
+      await recordError('plain string');
+
+      expect(recordExceptionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'plain string' }),
+      );
+    });
+
+    it('accepts an arbitrary object via String(...)', async () => {
+      await recordError({ weird: 1 });
+
+      expect(recordExceptionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('object') }),
+      );
+    });
+
+    it('sets custom keys with correct types', async () => {
+      const err = new Error('with-context');
+      await recordError(err, { route: '/x', count: 3, isAdmin: true });
+
+      expect(setCustomKeyMock).toHaveBeenCalledTimes(3);
+      expect(setCustomKeyMock).toHaveBeenCalledWith({
+        key: 'route',
+        value: '/x',
+        type: 'string',
+      });
+      expect(setCustomKeyMock).toHaveBeenCalledWith({
+        key: 'count',
+        value: 3,
+        type: 'long',
+      });
+      expect(setCustomKeyMock).toHaveBeenCalledWith({
+        key: 'isAdmin',
+        value: true,
+        type: 'boolean',
+      });
+    });
+
+    it('does not throw when recordException rejects', async () => {
+      recordExceptionMock.mockImplementationOnce(() =>
+        Promise.reject(new Error('plugin-fail')),
+      );
+
+      await expect(recordError(new Error('still ok'))).resolves.toBeUndefined();
+    });
+
+    it('does not throw when a single setCustomKey rejects', async () => {
+      setCustomKeyMock.mockImplementationOnce(() =>
+        Promise.reject(new Error('bad-key')),
+      );
+
+      await expect(
+        recordError(new Error('with bad key'), { route: '/x', count: 3 }),
+      ).resolves.toBeUndefined();
+
+      expect(recordExceptionMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('logCrashlyticsMessage', () => {
+    it('forwards messages to FirebaseCrashlytics.log', async () => {
+      await logCrashlyticsMessage('hello');
+      expect(logMock).toHaveBeenCalledWith({ message: 'hello' });
+    });
+
+    it('does not throw when log rejects', async () => {
+      logMock.mockImplementationOnce(() =>
+        Promise.reject(new Error('log-fail')),
+      );
+      await expect(logCrashlyticsMessage('bad')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('setCrashlyticsUserId', () => {
+    it('passes the user id through', async () => {
+      await setCrashlyticsUserId('user-123');
+      expect(setUserIdMock).toHaveBeenCalledWith({ userId: 'user-123' });
+    });
+
+    it('passes empty string for null', async () => {
+      await setCrashlyticsUserId(null);
+      expect(setUserIdMock).toHaveBeenCalledWith({ userId: '' });
+    });
+
+    it('does not throw when setUserId rejects', async () => {
+      setUserIdMock.mockImplementationOnce(() =>
+        Promise.reject(new Error('user-fail')),
+      );
+      await expect(setCrashlyticsUserId('x')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/components/firebase/crashlytics.ts
+++ b/src/components/firebase/crashlytics.ts
@@ -1,0 +1,124 @@
+import {
+  FirebaseCrashlytics,
+  type CustomKeyAndValue,
+  type StackFrame,
+} from '@capacitor-firebase/crashlytics';
+
+export type CrashlyticsContext = Record<string, string | number | boolean>;
+
+interface NormalizedError {
+  message: string;
+  stacktrace?: StackFrame[];
+}
+
+function normalize(error: unknown): NormalizedError {
+  if (error instanceof Error) {
+    return {
+      message: error.message || error.name || 'Error',
+      stacktrace: parseStack(error.stack),
+    };
+  }
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+  return { message: String(error) };
+}
+
+// V8/Chromium stack frame: "    at functionName (file:line:col)"
+//                          "    at file:line:col"
+// StackFrame im Plugin hat keine columnNumber — wird verworfen.
+const FRAME_NAMED = /^\s*at\s+(.+?)\s+\((.+?):(\d+):\d+\)\s*$/;
+const FRAME_ANON = /^\s*at\s+(.+?):(\d+):\d+\s*$/;
+
+function parseFrame(line: string): StackFrame | null {
+  const named = line.match(FRAME_NAMED);
+  if (named) {
+    return {
+      functionName: named[1],
+      fileName: named[2],
+      lineNumber: Number(named[3]),
+    };
+  }
+  const anon = line.match(FRAME_ANON);
+  if (anon) {
+    return {
+      fileName: anon[1],
+      lineNumber: Number(anon[2]),
+    };
+  }
+  return null;
+}
+
+function parseStack(stack?: string): StackFrame[] | undefined {
+  if (!stack) return undefined;
+  const frames: StackFrame[] = [];
+  for (const raw of stack.split('\n')) {
+    const frame = parseFrame(raw.trim());
+    if (frame) frames.push(frame);
+  }
+  return frames.length > 0 ? frames : undefined;
+}
+
+function pickType(
+  value: string | number | boolean,
+): CustomKeyAndValue['type'] {
+  if (typeof value === 'string') return 'string';
+  if (typeof value === 'boolean') return 'boolean';
+  return 'long';
+}
+
+async function applyContext(context: CrashlyticsContext): Promise<void> {
+  for (const [key, value] of Object.entries(context)) {
+    try {
+      await FirebaseCrashlytics.setCustomKey({
+        key,
+        value,
+        type: pickType(value),
+      });
+    } catch {
+      // best-effort; do not let a bad key swallow the actual error
+    }
+  }
+}
+
+export async function recordError(
+  error: unknown,
+  context?: CrashlyticsContext,
+): Promise<void> {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('[crashlytics] recordError', error, context);
+  }
+
+  try {
+    const normalized = normalize(error);
+
+    if (context) {
+      await applyContext(context);
+    }
+
+    await FirebaseCrashlytics.recordException({
+      message: normalized.message,
+      ...(normalized.stacktrace ? { stacktrace: normalized.stacktrace } : {}),
+    });
+  } catch {
+    // never throw — reporting failures must not break the app
+  }
+}
+
+export async function logCrashlyticsMessage(message: string): Promise<void> {
+  try {
+    await FirebaseCrashlytics.log({ message });
+  } catch {
+    // best-effort
+  }
+}
+
+export async function setCrashlyticsUserId(
+  userId: string | null,
+): Promise<void> {
+  try {
+    await FirebaseCrashlytics.setUserId({ userId: userId ?? '' });
+  } catch {
+    // best-effort
+  }
+}

--- a/src/components/providers/AppProviders.tsx
+++ b/src/components/providers/AppProviders.tsx
@@ -10,6 +10,7 @@ import React, { Suspense } from 'react';
 import About from '../../app/about/page';
 import useFirebaseAppCheck from '../../hooks/useFirebaseAppCheck';
 import useFirebaseLogin from '../../hooks/useFirebaseLogin';
+import useGlobalErrorReporter from '../../hooks/useGlobalErrorReporter';
 import useServerActionErrorDetection from '../../hooks/useServerActionErrorDetection';
 import useServiceWorkerUpdate from '../../hooks/useServiceWorkerUpdate';
 import { useCapacitorAppExit } from '../../hooks/useCapacitorAppExit';
@@ -20,6 +21,7 @@ import FirebaseUserProvider from '../firebase/FirebaseUserProvider';
 import DynamicLogin from '../pages/LoginUi';
 import AppDrawer from '../site/AppDrawer';
 import HeaderBar from '../site/HeaderBar';
+import ErrorBoundary from './ErrorBoundary';
 import FirecallLayerProvider from './FirecallLayerProvider';
 import FirecallProvider from './FirecallProvider';
 import MapEditorProvider from './MapEditorProvider';
@@ -102,6 +104,7 @@ function ServiceWorkerUpdateListener() {
 export default function AppProviders({ children }: AppProps) {
   useFirebaseAppCheck();
   useCapacitorAppExit();
+  useGlobalErrorReporter();
 
   return (
     <Suspense
@@ -111,21 +114,23 @@ export default function AppProviders({ children }: AppProps) {
         </Typography>
       }
     >
-      <SessionProvider>
-        <FirebaseUserProvider>
-          <SnackbarProvider>
-            <ServiceWorkerUpdateListener />
-            <DebugLoggingProvider>
-              <div className={`${styles.container} print-content-root`}>
-                <CssBaseline enableColorScheme />
-                <SingedOutOneTapLogin />
+      <ErrorBoundary>
+        <SessionProvider>
+          <FirebaseUserProvider>
+            <SnackbarProvider>
+              <ServiceWorkerUpdateListener />
+              <DebugLoggingProvider>
+                <div className={`${styles.container} print-content-root`}>
+                  <CssBaseline enableColorScheme />
+                  <SingedOutOneTapLogin />
 
-                <AuthorizationApp>{children}</AuthorizationApp>
-              </div>
-            </DebugLoggingProvider>
-          </SnackbarProvider>
-        </FirebaseUserProvider>
-      </SessionProvider>
+                  <AuthorizationApp>{children}</AuthorizationApp>
+                </div>
+              </DebugLoggingProvider>
+            </SnackbarProvider>
+          </FirebaseUserProvider>
+        </SessionProvider>
+      </ErrorBoundary>
     </Suspense>
   );
 }

--- a/src/components/providers/ErrorBoundary.test.tsx
+++ b/src/components/providers/ErrorBoundary.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const { recordErrorMock } = vi.hoisted(() => ({
+  recordErrorMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../firebase/crashlytics', () => ({
+  recordError: recordErrorMock,
+}));
+
+import ErrorBoundary from './ErrorBoundary';
+
+function Throwing(): React.ReactElement {
+  throw new Error('render-boom');
+}
+
+function Ok(): React.ReactElement {
+  return <span>ok-content</span>;
+}
+
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    recordErrorMock.mockClear();
+    consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders the German fallback when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Throwing />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Etwas ist schiefgelaufen')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Neu laden' })).toBeInTheDocument();
+  });
+
+  it('forwards the error and componentStack to recordError', () => {
+    render(
+      <ErrorBoundary>
+        <Throwing />
+      </ErrorBoundary>,
+    );
+
+    expect(recordErrorMock).toHaveBeenCalledTimes(1);
+    const firstCall = recordErrorMock.mock.calls[0] as unknown as [
+      unknown,
+      Record<string, unknown> | undefined,
+    ];
+    const err = firstCall[0];
+    const ctx = firstCall[1];
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('render-boom');
+    expect(ctx).toEqual(
+      expect.objectContaining({ source: 'react-error-boundary' }),
+    );
+  });
+
+  it('renders children unchanged when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <Ok />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('ok-content')).toBeInTheDocument();
+    expect(recordErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/providers/ErrorBoundary.tsx
+++ b/src/components/providers/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React from 'react';
+import { recordError } from '../firebase/crashlytics';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    void recordError(error, {
+      source: 'react-error-boundary',
+      componentStack: info.componentStack ?? '',
+    });
+  }
+
+  private handleReload = (): void => {
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  };
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+          <h2>Etwas ist schiefgelaufen</h2>
+          <p>Die Anwendung konnte nicht angezeigt werden. Bitte neu laden.</p>
+          <button onClick={this.handleReload}>Neu laden</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/hooks/useCrashlyticsUserSync.test.ts
+++ b/src/hooks/useCrashlyticsUserSync.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const setCrashlyticsUserIdMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('../components/firebase/crashlytics', () => ({
+  setCrashlyticsUserId: setCrashlyticsUserIdMock,
+}));
+
+import useCrashlyticsUserSync from './useCrashlyticsUserSync';
+
+interface Props {
+  uid: string | undefined;
+}
+
+describe('useCrashlyticsUserSync', () => {
+  beforeEach(() => {
+    setCrashlyticsUserIdMock.mockClear();
+  });
+
+  it('forwards a defined uid to Crashlytics', () => {
+    renderHook<void, Props>(({ uid }) => useCrashlyticsUserSync(uid), {
+      initialProps: { uid: 'user-123' },
+    });
+
+    expect(setCrashlyticsUserIdMock).toHaveBeenCalledTimes(1);
+    expect(setCrashlyticsUserIdMock).toHaveBeenCalledWith('user-123');
+  });
+
+  it('passes null when uid is undefined (signed-out state)', () => {
+    renderHook<void, Props>(({ uid }) => useCrashlyticsUserSync(uid), {
+      initialProps: { uid: undefined },
+    });
+
+    expect(setCrashlyticsUserIdMock).toHaveBeenCalledTimes(1);
+    expect(setCrashlyticsUserIdMock).toHaveBeenCalledWith(null);
+  });
+
+  it('does not re-call when uid stays the same across renders', () => {
+    const { rerender } = renderHook<void, Props>(
+      ({ uid }) => useCrashlyticsUserSync(uid),
+      { initialProps: { uid: 'user-123' } },
+    );
+
+    rerender({ uid: 'user-123' });
+    rerender({ uid: 'user-123' });
+
+    expect(setCrashlyticsUserIdMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates Crashlytics when uid changes (sign-in -> sign-out -> sign-in)', () => {
+    const { rerender } = renderHook<void, Props>(
+      ({ uid }) => useCrashlyticsUserSync(uid),
+      { initialProps: { uid: 'user-a' } },
+    );
+
+    rerender({ uid: undefined });
+    rerender({ uid: 'user-b' });
+
+    expect(setCrashlyticsUserIdMock).toHaveBeenCalledTimes(3);
+    expect(setCrashlyticsUserIdMock).toHaveBeenNthCalledWith(1, 'user-a');
+    expect(setCrashlyticsUserIdMock).toHaveBeenNthCalledWith(2, null);
+    expect(setCrashlyticsUserIdMock).toHaveBeenNthCalledWith(3, 'user-b');
+  });
+});

--- a/src/hooks/useCrashlyticsUserSync.ts
+++ b/src/hooks/useCrashlyticsUserSync.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import { setCrashlyticsUserId } from '../components/firebase/crashlytics';
+
+export default function useCrashlyticsUserSync(
+  uid: string | undefined,
+): void {
+  useEffect(() => {
+    void setCrashlyticsUserId(uid ?? null);
+  }, [uid]);
+}

--- a/src/hooks/useGlobalErrorReporter.test.ts
+++ b/src/hooks/useGlobalErrorReporter.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const { recordErrorMock } = vi.hoisted(() => ({
+  recordErrorMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../components/firebase/crashlytics', () => ({
+  recordError: recordErrorMock,
+}));
+
+import useGlobalErrorReporter from './useGlobalErrorReporter';
+
+describe('useGlobalErrorReporter', () => {
+  beforeEach(() => {
+    recordErrorMock.mockClear();
+    window.onerror = null;
+  });
+
+  afterEach(() => {
+    window.onerror = null;
+  });
+
+  it('forwards window.onerror invocations to recordError', () => {
+    renderHook(() => useGlobalErrorReporter());
+
+    const err = new Error('boom');
+    window.onerror?.('msg', 'file.js', 1, 1, err);
+
+    expect(recordErrorMock).toHaveBeenCalledTimes(1);
+    expect(recordErrorMock).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({ source: 'window.onerror' }),
+    );
+  });
+
+  it('falls back to the message when no Error object is provided', () => {
+    renderHook(() => useGlobalErrorReporter());
+
+    window.onerror?.('msg only', 'file.js', 1, 1, undefined);
+
+    expect(recordErrorMock).toHaveBeenCalledTimes(1);
+    expect(recordErrorMock).toHaveBeenCalledWith(
+      'msg only',
+      expect.objectContaining({ source: 'window.onerror' }),
+    );
+  });
+
+  it('forwards unhandledrejection events to recordError', () => {
+    renderHook(() => useGlobalErrorReporter());
+
+    const reason = new Error('rejected');
+    const event = new Event('unhandledrejection') as Event & {
+      reason?: unknown;
+    };
+    event.reason = reason;
+    window.dispatchEvent(event);
+
+    expect(recordErrorMock).toHaveBeenCalledTimes(1);
+    expect(recordErrorMock).toHaveBeenCalledWith(
+      reason,
+      expect.objectContaining({ source: 'unhandledrejection' }),
+    );
+  });
+
+  it('removes both listeners on unmount', () => {
+    const { unmount } = renderHook(() => useGlobalErrorReporter());
+    unmount();
+
+    recordErrorMock.mockClear();
+
+    window.onerror?.('msg', 'file.js', 1, 1, new Error('after'));
+    const event = new Event('unhandledrejection') as Event & {
+      reason?: unknown;
+    };
+    event.reason = new Error('after-rejection');
+    window.dispatchEvent(event);
+
+    expect(recordErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves and chains a previously installed window.onerror', () => {
+    const previous = vi.fn();
+    window.onerror = previous;
+
+    renderHook(() => useGlobalErrorReporter());
+
+    const err = new Error('chain');
+    window.onerror?.('msg', 'file.js', 5, 5, err);
+
+    expect(previous).toHaveBeenCalledTimes(1);
+    expect(recordErrorMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useGlobalErrorReporter.ts
+++ b/src/hooks/useGlobalErrorReporter.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+import { recordError } from '../components/firebase/crashlytics';
+
+export default function useGlobalErrorReporter(): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const previousOnError = window.onerror;
+
+    const onError: OnErrorEventHandler = (
+      message,
+      source,
+      lineno,
+      colno,
+      error,
+    ) => {
+      try {
+        const target = error ?? message;
+        void recordError(target, {
+          source: 'window.onerror',
+          ...(typeof source === 'string' ? { fileName: source } : {}),
+          ...(typeof lineno === 'number' ? { lineNumber: lineno } : {}),
+          ...(typeof colno === 'number' ? { columnNumber: colno } : {}),
+        });
+      } catch {
+        // best-effort
+      }
+
+      if (typeof previousOnError === 'function') {
+        return previousOnError(message, source, lineno, colno, error);
+      }
+      return false;
+    };
+
+    window.onerror = onError;
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+      const reason: unknown = (event as Event & { reason?: unknown }).reason;
+      void recordError(reason ?? 'unhandledrejection', {
+        source: 'unhandledrejection',
+      });
+    };
+
+    window.addEventListener(
+      'unhandledrejection',
+      onUnhandledRejection as EventListener,
+    );
+
+    return () => {
+      if (window.onerror === onError) {
+        window.onerror = previousOnError ?? null;
+      }
+      window.removeEventListener(
+        'unhandledrejection',
+        onUnhandledRejection as EventListener,
+      );
+    };
+  }, []);
+}


### PR DESCRIPTION
## Zusammenfassung

Der erste Play-Store-Release wurde von Google abgelehnt, weil die App auf den Test-Geräten gecrasht ist — ohne Stack-Trace, nur ein Screenshot. Damit zukünftige Crashes diagnostizierbar sind und nicht direkt zu einer App-Beendigung führen, wird Firebase Crashlytics nativ und auf JS-Seite integriert, plus React- und WebView-Error-Boundaries.

## Änderungen

**Native Android (`capacitor/android/`)**

- `firebase-crashlytics-gradle:3.0.2` Classpath + Plugin-Anwendung (gated auf `google-services.json`)
- `firebase-crashlytics-ktx` über die bestehende Firebase BoM 33.3.0
- `MainActivity.onRenderProcessGone` Override: meldet Renderer-Crash an Crashlytics, entfernt + zerstört die tote WebView (Android-Vertrag), ruft `recreate()` auf — App wird nicht mehr von Android gekillt

**JS-Seite (`src/`)**

- `@capacitor-firebase/crashlytics@^8.2.0` Plugin
- `src/components/firebase/crashlytics.ts` — typisierter Wrapper mit `recordError`, `logCrashlyticsMessage`, `setCrashlyticsUserId`. Best-effort, never-throws, strukturierte StackFrame-Parser, Dev-only `console.warn`
- `src/components/providers/ErrorBoundary.tsx` — React-Class-Boundary mit deutscher Fallback-UI ("Etwas ist schiefgelaufen" / "Neu laden"), am Root von `AppProviders` eingehängt
- `src/hooks/useGlobalErrorReporter.ts` — chained `window.onerror` + `unhandledrejection`-Listener
- `src/hooks/useCrashlyticsUserSync.ts` — synct Firebase-Auth-uid in Crashlytics auf Login/Logout
- `src/app/error.tsx` + `src/app/global-error.tsx` leiten Errors an Crashlytics weiter, Strings auf Deutsch

**Tests**

- 23 neue Vitest-Tests (TDD für alle neuen Module)
- Gesamtsuite: 923 passed, 1 skipped (vorher 919, der Skip ist ein vorbestehender Radiacode-Test)

## Test plan

- [ ] `npm run check` lokal grün (tsc, eslint, vitest, build) — bereits bestätigt
- [ ] Android Debug-Build via `npm run build:android` baut durch
- [ ] Crashlytics-Dashboard zeigt Test-Crash nach `FirebaseCrashlytics.crash()` (manueller Test im Debug-Build)
- [ ] In der gerenderten App testweise einen JS-Fehler in einer Komponente provozieren → ErrorBoundary-Fallback erscheint, Eintrag landet in Crashlytics
- [ ] Sign-In/Sign-Out → user-id im Crashlytics-Dashboard wird gesetzt bzw. geleert
- [ ] Pre-Launch-Test im Play-Console aktivieren, neuen Internal-Track-Build hochladen — sollte mit Crashlytics nun einen verwertbaren Stack-Trace liefern, falls der Crash erneut auftritt

## Offene Follow-ups (bewusst nicht in diesem PR)

- ProGuard-Mapping-Upload (`uploadCrashlyticsMappingFileRelease`) — relevant erst falls `minifyEnabled true` aktiviert wird
- `FirebaseCrashlytics.setEnabled` als Consent-Gate — aktuell ist Auto-Collection aktiv (Default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)