### PR TITLE
fix(ci): add changesNotSentForReview to Play Store commit

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -180,7 +180,7 @@ jobs:
           done
 
           echo "==> Committing edit"
-          gcall -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "${API}/edits/${EDIT_ID}:commit" >/dev/null
+          gcall -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "${API}/edits/${EDIT_ID}:commit?changesNotSentForReview=true" >/dev/null
           echo "Done — versionName=${VERSION_NAME} versionCode=${UPLOADED_VC} tracks=${TRACKS}"
 
       - name: Attach AAB to GitHub Release


### PR DESCRIPTION
## Zusammenfassung

Behebt den HTTP 400 Fehler beim automatischen Play Store Publish im Android-Release-Workflow. Google Play API verlangt mittlerweile den Query-Parameter `changesNotSentForReview=true` am `:commit`-Endpoint.

## Hintergrund

Der Release-Workflow für `v2.50.0` ist mit folgender Fehlermeldung fehlgeschlagen:

```
HTTP 400 from -X POST https://androidpublisher.googleapis.com/.../edits/.../:commit
{
  "error": {
    "code": 400,
    "message": "Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.",
    "status": "INVALID_ARGUMENT"
  }
}
```

Der AAB-Upload und die Track-Zuweisung waren erfolgreich, nur das finale `:commit` schlug fehl.

## Änderungen

- `?changesNotSentForReview=true` an die Commit-URL angehängt in [`.github/workflows/android-release.yml`](.github/workflows/android-release.yml)

Nach dem Commit über die API muss das Release weiterhin manuell über die Google Play Console UI zur Überprüfung eingereicht werden ("Send for review").

## Test plan

- [ ] Workflow `Android Release` manuell mit `workflow_dispatch` (alpha-Build) triggern und prüfen, dass der Commit-Step ohne HTTP 400 durchläuft
- [ ] In der Play Console verifizieren, dass das Release als Entwurf erscheint und manuell zur Review eingereicht werden kann

🤖 Generated with [Claude Code](https://claude.com/claude-code)