### PR TITLE
fix(auth): pass uid directly to refresh to avoid stale closure on reload

### DIFF
--- a/src/hooks/useFirebaseLoginObserver.ts
+++ b/src/hooks/useFirebaseLoginObserver.ts
@@ -84,11 +84,19 @@ export default function useFirebaseLoginObserver(): LoginStatus {
     }
   }, []);
 
-  const refresh = useCallback(async () => {
-    if (!uid) return;
+  const refresh = useCallback(async (refreshUid?: string) => {
+    // Allow caller (e.g. onAuthStateChanged) to pass uid directly to bypass
+    // a React state race: setUid triggers a render, but if all subsequent
+    // awaits resolve from cache (Firebase token), React may not commit before
+    // refresh runs — leaving the captured `uid` from this closure stale.
+    const effectiveUid = refreshUid ?? uid;
+    if (!effectiveUid) return;
 
     try {
-      const groups = await getMyGroupsFromServer().catch(() => [] as Group[]);
+      const groups = await getMyGroupsFromServer().catch((err) => {
+        console.error('getMyGroupsFromServer failed:', err);
+        return [] as Group[];
+      });
       setMyGroups(groups);
 
       const hasSessionData = session?.user?.isAuthorized !== undefined;
@@ -109,7 +117,11 @@ export default function useFirebaseLoginObserver(): LoginStatus {
           isRefreshing: false,
         }));
       } else {
-        await handleFirestoreBasedRefresh(uid, setNeedsReLogin, setLoginStatus);
+        await handleFirestoreBasedRefresh(
+          effectiveUid,
+          setNeedsReLogin,
+          setLoginStatus
+        );
       }
     } catch (err) {
       console.error(`failed to refresh user data`, err);
@@ -171,7 +183,7 @@ export default function useFirebaseLoginObserver(): LoginStatus {
           };
 
           setLoginStatus((prev) => ({ ...prev, ...authData }));
-          await refreshRef.current();
+          await refreshRef.current(user.uid);
           setLoginStatus((prev) => ({ ...prev, loginStep: 'done' }));
           console.info(`login completed for ${user.email}`);
         } else {


### PR DESCRIPTION
## Zusammenfassung

Behebt einen Race-Bug, durch den nach einem Page-Reload (F5) die Gruppen verschwinden — Folge: kein neuer Einsatz anlegbar (Gruppen-Dropdown leer) und kein Einsatz mehr abrufbar (\`where('group', 'in', [])\` failt).

## Ursache

In [useFirebaseLoginObserver.ts](src/hooks/useFirebaseLoginObserver.ts) ruft \`onAuthStateChanged\` \`setUid(user.uid)\` auf, danach folgen mehrere \`await user.getIdToken*()\`-Aufrufe. Diese resolven synchron aus dem Firebase-Cache, sodass React zwischen \`setUid\` und \`await refreshRef.current()\` **nicht rendert**. Die \`refresh\`-Closure in der Ref behält damit ihr stales \`uid: undefined\` und der Early-Return greift — \`myGroups\` bleibt leer, \`loginStatus.groups\` wird nie geschrieben.

## Änderungen

- \`refresh\` akzeptiert jetzt einen optionalen \`refreshUid\`-Parameter
- Im Auth-Observer wird \`await refreshRef.current(user.uid)\` mit der Firebase-uid direkt aufgerufen — bypasst den React-State
- Externe Konsumenten rufen weiterhin \`refresh()\` ohne Argument auf
- \`getMyGroupsFromServer\`-Fehler werden statt still geschluckt jetzt via \`console.error\` geloggt

## Test plan

- [x] \`npx tsc --noEmit\` sauber
- [x] \`npx eslint\` sauber
- [x] \`npx vitest run\` — 936 passed, 1 skipped
- [x] Manueller Test: Login → F5 → Gruppen sichtbar, Dropdown gefüllt, Einsatzliste lädt

🤖 Generated with [Claude Code](https://claude.com/claude-code)