### PR TITLE
feat: live location sharing per firecall

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -180,7 +180,32 @@ jobs:
           done
 
           echo "==> Committing edit"
-          gcall -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "${API}/edits/${EDIT_ID}:commit?changesNotSentForReview=true" >/dev/null
+          commit_resp=$(mktemp)
+          commit_code=$(curl -sS -o "${commit_resp}" -w "%{http_code}" \
+            -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            "${API}/edits/${EDIT_ID}:commit")
+          if [[ "${commit_code}" =~ ^2[0-9]{2}$ ]]; then
+            echo "Edit committed (auto-submitted for review)"
+          elif [[ "${commit_code}" == "400" ]] && grep -q "changesNotSentForReview" "${commit_resp}"; then
+            echo "Auto-review unavailable for this edit, retrying with changesNotSentForReview=true"
+            cat "${commit_resp}" >&2
+            retry_code=$(curl -sS -o "${commit_resp}" -w "%{http_code}" \
+              -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              "${API}/edits/${EDIT_ID}:commit?changesNotSentForReview=true")
+            if [[ ! "${retry_code}" =~ ^2[0-9]{2}$ ]]; then
+              echo "HTTP ${retry_code} from commit retry" >&2
+              cat "${commit_resp}" >&2
+              rm -f "${commit_resp}"
+              exit 1
+            fi
+            echo "::warning::Edit committed without auto-review. Submit manually in the Play Console."
+          else
+            echo "HTTP ${commit_code} from commit" >&2
+            cat "${commit_resp}" >&2
+            rm -f "${commit_resp}"
+            exit 1
+          fi
+          rm -f "${commit_resp}"
           echo "Done — versionName=${VERSION_NAME} versionCode=${UPLOADED_VC} tracks=${TRACKS}"
 
       - name: Attach AAB to GitHub Release

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ hydranten.csv
 certificates
 /radiacode-python/
 .claude/scheudled_tasks.lock
+*.aab

--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt
@@ -28,6 +28,9 @@ import at.ffnd.einsatzkarte.gpstrack.FirestoreLineUpdater
 import at.ffnd.einsatzkarte.gpstrack.GpsTrackConfig
 import at.ffnd.einsatzkarte.gpstrack.GpsTrackRecorder
 import at.ffnd.einsatzkarte.gpstrack.LineUpdater
+import at.ffnd.einsatzkarte.livelocation.FirestoreLiveLocationDocWriter
+import at.ffnd.einsatzkarte.livelocation.LiveLocationConfig
+import at.ffnd.einsatzkarte.livelocation.LiveLocationPusher
 import at.ffnd.einsatzkarte.radiacode.Measurement
 import at.ffnd.einsatzkarte.radiacode.MeasurementMapper
 import at.ffnd.einsatzkarte.radiacode.RadiaCode
@@ -77,6 +80,9 @@ class RadiacodeForegroundService : Service() {
         const val ACTION_STOP_TRACK = "at.ffnd.einsatzkarte.RADIACODE_STOP_TRACK"
         const val ACTION_START_GPS_TRACK = "at.ffnd.einsatzkarte.GPS_TRACK_START"
         const val ACTION_STOP_GPS_TRACK = "at.ffnd.einsatzkarte.GPS_TRACK_STOP"
+        const val ACTION_START_LIVE_SHARE  = "at.ffnd.einsatzkarte.LIVE_SHARE_START"
+        const val ACTION_STOP_LIVE_SHARE   = "at.ffnd.einsatzkarte.LIVE_SHARE_STOP"
+        const val ACTION_UPDATE_LIVE_SHARE = "at.ffnd.einsatzkarte.LIVE_SHARE_UPDATE"
 
         const val EXTRA_TITLE = "title"
         const val EXTRA_BODY = "body"
@@ -94,6 +100,12 @@ class RadiacodeForegroundService : Service() {
         const val EXTRA_CUSTOM_DOSE_DELTA = "customDoseRateDeltaUSvH"
         const val EXTRA_INITIAL_LAT = "initialLat"
         const val EXTRA_INITIAL_LNG = "initialLng"
+        const val EXTRA_LIVE_UID = "liveUid"
+        const val EXTRA_LIVE_NAME = "liveName"
+        const val EXTRA_LIVE_EMAIL = "liveEmail"
+        const val EXTRA_LIVE_INTERVAL_MS = "liveIntervalMs"
+        const val EXTRA_LIVE_DISTANCE_M = "liveDistanceM"
+        const val EXTRA_LIVE_FIRECALL_NAME = "liveFirecallName"
 
         private const val TAG = "RadiacodeFg"
         // 2 s Poll-Takt — angeglichen an radiacode-python `basic.py`. Bei 1 s
@@ -199,6 +211,8 @@ class RadiacodeForegroundService : Service() {
     @Volatile private var lastLocation: android.location.Location? = null
     @Volatile private var trackRecorder: TrackRecorder? = null
     @Volatile private var gpsTrackRecorder: GpsTrackRecorder? = null
+    @Volatile private var liveLocationPusher: LiveLocationPusher? = null
+    @Volatile private var liveShareFirecallName: String = ""
 
     // Letzte gesehene Rare-Felder für Late-Connect / leere Ticks. Werden in
     // `onMeasurementReceived` aktualisiert und bei `teardownSession` gelöscht,
@@ -212,6 +226,7 @@ class RadiacodeForegroundService : Service() {
     fun getDeviceAddress(): String? = currentAddress
     fun isRadiacodeTracking(): Boolean = trackRecorder != null
     fun isGpsTracking(): Boolean = gpsTrackRecorder != null
+    fun isLiveShareActive(): Boolean = liveLocationPusher != null
 
     /**
      * Synchroner Wire-Level-Execute für den TS-Plugin-Pfad. Schreibt einen
@@ -278,8 +293,8 @@ class RadiacodeForegroundService : Service() {
                 // hier stopSelf() rufen, killt Android den gesamten Service
                 // inklusive GATT-Session — siehe Bug-Analyse 2026-04-22.
                 // Session-Teardown ausschliesslich via ACTION_BLE_DISCONNECT.
-                if (radiaCode != null || gpsTrackRecorder != null) {
-                    Log.w(TAG, "ACTION_STOP ignoriert — Session/GPS-Track aktiv, Service bleibt laufen")
+                if (radiaCode != null || gpsTrackRecorder != null || liveLocationPusher != null) {
+                    Log.w(TAG, "ACTION_STOP ignoriert — Session/GPS-Track/Live-Share aktiv, Service bleibt laufen")
                 } else {
                     Log.i(TAG, "ACTION_STOP — keine Session, Service wird beendet")
                     releaseWakeLock()
@@ -301,8 +316,8 @@ class RadiacodeForegroundService : Service() {
             }
             ACTION_BLE_DISCONNECT -> {
                 teardownSession()
-                if (gpsTrackRecorder == null) {
-                    Log.i(TAG, "ACTION_BLE_DISCONNECT — no GPS track, stopping service")
+                if (gpsTrackRecorder == null && liveLocationPusher == null) {
+                    Log.i(TAG, "ACTION_BLE_DISCONNECT — no GPS track / live-share, stopping service")
                     stopHighAccuracyLocation()
                     releaseWakeLock()
                     stopForeground(STOP_FOREGROUND_REMOVE)
@@ -382,13 +397,90 @@ class RadiacodeForegroundService : Service() {
                 Log.i(TAG, "GPS track stop")
                 gpsTrackRecorder?.stop()
                 gpsTrackRecorder = null
-                if (radiaCode == null) {
+                if (radiaCode == null && liveLocationPusher == null) {
                     stopHighAccuracyLocation()
                     releaseWakeLock()
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     stopSelf()
                 } else {
                     updateNotificationForState()
+                }
+            }
+            ACTION_START_LIVE_SHARE -> {
+                val firecallId = intent?.getStringExtra(EXTRA_FIRECALL_ID)
+                val uid        = intent?.getStringExtra(EXTRA_LIVE_UID)
+                val nm         = intent?.getStringExtra(EXTRA_LIVE_NAME) ?: ""
+                val email      = intent?.getStringExtra(EXTRA_LIVE_EMAIL) ?: ""
+                val intervalMs = intent?.getLongExtra(EXTRA_LIVE_INTERVAL_MS, 5_000L) ?: 5_000L
+                val distanceM  = intent?.getDoubleExtra(EXTRA_LIVE_DISTANCE_M, 25.0) ?: 25.0
+                val firecallNm = intent?.getStringExtra(EXTRA_LIVE_FIRECALL_NAME) ?: ""
+                val firestoreDb = intent?.getStringExtra(EXTRA_FIRESTORE_DB) ?: ""
+                if (firecallId.isNullOrBlank() || uid.isNullOrBlank()) {
+                    Log.w(TAG, "ACTION_START_LIVE_SHARE rejected — missing firecallId/uid")
+                } else {
+                    val cfg = LiveLocationConfig(
+                        firecallId = firecallId, uid = uid, name = nm, email = email,
+                    )
+                    // Existierenden Pusher (anderer Firecall/UID) sauber abdrehen.
+                    liveLocationPusher?.let { prev ->
+                        prev.stop()
+                        prev.deleteDoc()
+                    }
+                    val sink = FirestoreLiveLocationDocWriter(firestoreDb)
+                    val pusher = LiveLocationPusher(cfg, sink, intervalMs, distanceM)
+                    liveLocationPusher = pusher
+                    liveShareFirecallName = firecallNm
+                    acquireWakeLock()
+                    startHighAccuracyLocation()
+                    // Wenn schon ein Fix vorliegt, sofort einen ersten Sample
+                    // schreiben — analog zu ACTION_START_GPS_TRACK.
+                    lastLocation?.let { loc ->
+                        pusher.onLocation(
+                            loc.latitude, loc.longitude,
+                            accuracy = loc.accuracy.toDouble().takeIf { loc.hasAccuracy() },
+                            heading  = loc.bearing.toDouble().takeIf { loc.hasBearing() },
+                            speed    = loc.speed.toDouble().takeIf { loc.hasSpeed() },
+                        )
+                    }
+                    updateNotificationForState()
+                    Log.i(
+                        TAG,
+                        "live-share started firecall=$firecallId uid=$uid intervalMs=$intervalMs distanceM=$distanceM",
+                    )
+                }
+            }
+            ACTION_STOP_LIVE_SHARE -> {
+                Log.i(TAG, "live-share stop")
+                liveLocationPusher?.let { p ->
+                    p.stop()
+                    // Best-effort delete — der Service darf darauf nicht warten,
+                    // sondern teardown'd asynchron. Wenn der Service direkt
+                    // danach beendet wird, holt die Firestore-TTL (~1 h) den
+                    // Doc-Cleanup nach.
+                    p.deleteDoc()
+                }
+                liveLocationPusher = null
+                liveShareFirecallName = ""
+                if (radiaCode == null && gpsTrackRecorder == null) {
+                    stopHighAccuracyLocation()
+                    releaseWakeLock()
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                    stopSelf()
+                } else {
+                    updateNotificationForState()
+                }
+            }
+            ACTION_UPDATE_LIVE_SHARE -> {
+                val intervalMs = intent?.getLongExtra(EXTRA_LIVE_INTERVAL_MS, -1L) ?: -1L
+                val distanceM  = intent?.getDoubleExtra(EXTRA_LIVE_DISTANCE_M, -1.0) ?: -1.0
+                val pusher = liveLocationPusher
+                if (pusher == null) {
+                    Log.i(TAG, "ACTION_UPDATE_LIVE_SHARE ignored — pusher not running")
+                } else if (intervalMs <= 0L || distanceM < 0.0) {
+                    Log.w(TAG, "ACTION_UPDATE_LIVE_SHARE rejected — invalid intervalMs=$intervalMs distanceM=$distanceM")
+                } else {
+                    pusher.updateSettings(intervalMs, distanceM)
+                    Log.i(TAG, "live-share settings updated intervalMs=$intervalMs distanceM=$distanceM")
                 }
             }
         }
@@ -449,6 +541,12 @@ class RadiacodeForegroundService : Service() {
         trackRecorder = null
         gpsTrackRecorder?.stop()
         gpsTrackRecorder = null
+        liveLocationPusher?.let { p ->
+            p.stop()
+            p.deleteDoc()
+        }
+        liveLocationPusher = null
+        liveShareFirecallName = ""
         stopHighAccuracyLocation()
         releaseWakeLock()
         bleWorker?.shutdown()
@@ -462,6 +560,13 @@ class RadiacodeForegroundService : Service() {
 
         gpsTrackRecorder?.stop()
         gpsTrackRecorder = null
+
+        liveLocationPusher?.let { p ->
+            p.stop()
+            p.deleteDoc()
+        }
+        liveLocationPusher = null
+        liveShareFirecallName = ""
 
         teardownSession()
 
@@ -832,6 +937,12 @@ class RadiacodeForegroundService : Service() {
                 result.lastLocation?.let { loc ->
                     lastLocation = loc
                     gpsTrackRecorder?.onLocation(loc.latitude, loc.longitude)
+                    liveLocationPusher?.onLocation(
+                        loc.latitude, loc.longitude,
+                        accuracy = loc.accuracy.toDouble().takeIf { loc.hasAccuracy() },
+                        heading  = loc.bearing.toDouble().takeIf { loc.hasBearing() },
+                        speed    = loc.speed.toDouble().takeIf { loc.hasSpeed() },
+                    )
                 }
             }
         }
@@ -875,13 +986,27 @@ class RadiacodeForegroundService : Service() {
     }
 
     private fun updateNotificationForState() {
+        val track = gpsTrackRecorder != null || trackRecorder != null
+        val liveShare = liveLocationPusher != null
         val title = when {
-            radiaCode == null -> "Radiacode getrennt"
-            !deviceReady -> "Radiacode – Verbindung verloren"
-            gpsTrackRecorder != null && trackRecorder != null -> "Radiacode + GPS-Aufzeichnung"
-            trackRecorder != null -> "Strahlenmessung läuft"
-            gpsTrackRecorder != null -> "GPS-Aufzeichnung läuft"
-            else -> "Radiacode verbunden"
+            radiaCode != null && !deviceReady -> "Radiacode – Verbindung verloren"
+            radiaCode != null && trackRecorder != null && gpsTrackRecorder != null -> "Radiacode + GPS-Aufzeichnung"
+            radiaCode != null && trackRecorder != null -> "Strahlenmessung läuft"
+            radiaCode != null && gpsTrackRecorder != null -> "Radiacode + GPS-Aufzeichnung"
+            radiaCode != null -> "Radiacode verbunden"
+            // Kein Radiacode aktiv — Modi nur GPS-Track / Live-Share
+            track && liveShare -> {
+                val name = liveShareFirecallName
+                if (name.isBlank()) "Standort wird aufgezeichnet & geteilt"
+                else "Standort wird aufgezeichnet & geteilt — $name"
+            }
+            liveShare -> {
+                val name = liveShareFirecallName
+                if (name.isBlank()) "Live-Standort wird geteilt"
+                else "Live-Standort wird geteilt — $name"
+            }
+            track -> "GPS-Aufzeichnung läuft"
+            else -> "Radiacode getrennt"
         }
         lastTitle = title
         ensureForeground()

--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeNotificationPlugin.java
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeNotificationPlugin.java
@@ -76,11 +76,13 @@ public class RadiacodeNotificationPlugin extends Plugin {
             ret.put("deviceAddress", service.getDeviceAddress());
             ret.put("radiacodeTracking", service.isRadiacodeTracking());
             ret.put("gpsTracking", service.isGpsTracking());
+            ret.put("liveShareActive", service.isLiveShareActive());
         } else {
             ret.put("connected", false);
             ret.put("deviceAddress", null);
             ret.put("radiacodeTracking", false);
             ret.put("gpsTracking", false);
+            ret.put("liveShareActive", false);
         }
         call.resolve(ret);
     }
@@ -226,6 +228,70 @@ public class RadiacodeNotificationPlugin extends Plugin {
         Log.i(TAG, "plugin.stopGpsTrack");
         Intent intent = new Intent(getContext(), RadiacodeForegroundService.class);
         intent.setAction(RadiacodeForegroundService.ACTION_STOP_GPS_TRACK);
+        getContext().startService(intent);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void startLiveShare(PluginCall call) {
+        String firecallId   = call.getString("firecallId");
+        String uid          = call.getString("uid");
+        String name         = call.getString("name", "");
+        String email        = call.getString("email", "");
+        Integer intervalMs  = call.getInt("intervalMs");
+        Double  distanceM   = call.getDouble("distanceM");
+        String  firecallNm  = call.getString("firecallName", "");
+        String  firestoreDb = call.getString("firestoreDb", "");
+        if (firecallId == null || firecallId.isEmpty()
+            || uid == null || uid.isEmpty()
+            || intervalMs == null
+            || distanceM == null) {
+            Log.w(TAG, "plugin.startLiveShare rejected — missing firecallId/uid/intervalMs/distanceM");
+            call.reject("firecallId, uid, intervalMs, distanceM required");
+            return;
+        }
+        Log.i(TAG, "plugin.startLiveShare firecallId=" + firecallId + " uid=" + uid
+            + " intervalMs=" + intervalMs + " distanceM=" + distanceM);
+        Intent intent = new Intent(getContext(), RadiacodeForegroundService.class);
+        intent.setAction(RadiacodeForegroundService.ACTION_START_LIVE_SHARE);
+        intent.putExtra(RadiacodeForegroundService.EXTRA_FIRECALL_ID, firecallId);
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_UID, uid);
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_NAME, name);
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_EMAIL, email);
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_INTERVAL_MS, intervalMs.longValue());
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_DISTANCE_M, distanceM.doubleValue());
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_FIRECALL_NAME, firecallNm == null ? "" : firecallNm);
+        intent.putExtra(RadiacodeForegroundService.EXTRA_FIRESTORE_DB, firestoreDb == null ? "" : firestoreDb);
+        startService(intent);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void stopLiveShare(PluginCall call) {
+        Log.i(TAG, "plugin.stopLiveShare");
+        Intent intent = new Intent(getContext(), RadiacodeForegroundService.class);
+        intent.setAction(RadiacodeForegroundService.ACTION_STOP_LIVE_SHARE);
+        getContext().startService(intent);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void updateLiveShareSettings(PluginCall call) {
+        Integer intervalMs = call.getInt("intervalMs");
+        Double  distanceM  = call.getDouble("distanceM");
+        if (intervalMs == null || distanceM == null) {
+            Log.w(TAG, "plugin.updateLiveShareSettings rejected — intervalMs/distanceM required");
+            call.reject("intervalMs and distanceM required");
+            return;
+        }
+        Log.i(TAG, "plugin.updateLiveShareSettings intervalMs=" + intervalMs + " distanceM=" + distanceM);
+        Intent intent = new Intent(getContext(), RadiacodeForegroundService.class);
+        intent.setAction(RadiacodeForegroundService.ACTION_UPDATE_LIVE_SHARE);
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_INTERVAL_MS, intervalMs.longValue());
+        intent.putExtra(RadiacodeForegroundService.EXTRA_LIVE_DISTANCE_M, distanceM.doubleValue());
+        // Service läuft bereits, wenn diese Action sinnvoll ist — kein
+        // startForegroundService() nötig. Wenn der Service nicht läuft, ist
+        // der Update sowieso ein No-op.
         getContext().startService(intent);
         call.resolve();
     }

--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/livelocation/LiveLocationDocWriter.kt
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/livelocation/LiveLocationDocWriter.kt
@@ -1,0 +1,118 @@
+package at.ffnd.einsatzkarte.livelocation
+
+import android.util.Log
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import java.util.Date
+
+/**
+ * Identity + invariant fields for a Live-Location entry. uid, name, email
+ * stay constant for the lifetime of the pusher; lat/lng/accuracy/heading/speed
+ * change on every GPS sample.
+ */
+data class LiveLocationConfig(
+    val firecallId: String,
+    val uid: String,
+    val name: String,
+    val email: String,
+)
+
+/**
+ * Single GPS sample to push. Optional fields stay null when the platform
+ * does not provide them (e.g. heading/speed during a GPS standstill).
+ */
+data class LiveLocationSample(
+    val lat: Double,
+    val lng: Double,
+    val accuracy: Double?,
+    val heading: Double?,
+    val speed: Double?,
+)
+
+interface LiveLocationDocSink {
+    fun writeSample(
+        config: LiveLocationConfig,
+        sample: LiveLocationSample,
+        onSuccess: () -> Unit = {},
+        onFailure: (Throwable) -> Unit = {},
+    )
+
+    fun deleteDoc(
+        config: LiveLocationConfig,
+        onSuccess: () -> Unit = {},
+        onFailure: (Throwable) -> Unit = {},
+    )
+}
+
+/**
+ * Schreibt das `call/{firecallId}/livelocation/{uid}`-Dokument für den
+ * eingeloggten Nutzer. Schemafelder müssen mit der TS-Seite übereinstimmen:
+ *
+ *  - `uid`, `name`, `email` (string)
+ *  - `lat`, `lng` (double)
+ *  - `accuracy`, `heading`, `speed` (optional, double — null wird ausgelassen)
+ *  - `updatedAt` = Server-Timestamp (FieldValue.serverTimestamp())
+ *  - `expiresAt` = `Timestamp` von `now + TTL_HOURS` für Firestore-TTL-Cleanup
+ *
+ * Pro Aufruf wird `set(merge=true)` verwendet, sodass eine einzige
+ * Schreiboperation reicht und das Dokument auch dann angelegt wird, wenn
+ * es noch nicht existiert.
+ */
+class FirestoreLiveLocationDocWriter(dbName: String) : LiveLocationDocSink {
+
+    companion object {
+        private const val TAG = "LiveLocation"
+        private const val TTL_MS = 60L * 60L * 1000L
+    }
+
+    private val firestore: FirebaseFirestore = (
+        if (dbName.isBlank()) FirebaseFirestore.getInstance()
+        else FirebaseFirestore.getInstance(dbName)
+    ).also {
+        Log.i(TAG, "Firestore DB = ${if (dbName.isBlank()) "(default)" else dbName}")
+    }
+
+    override fun writeSample(
+        config: LiveLocationConfig,
+        sample: LiveLocationSample,
+        onSuccess: () -> Unit,
+        onFailure: (Throwable) -> Unit,
+    ) {
+        val data = linkedMapOf<String, Any>(
+            "uid" to config.uid,
+            "name" to config.name,
+            "email" to config.email,
+            "lat" to sample.lat,
+            "lng" to sample.lng,
+            "updatedAt" to FieldValue.serverTimestamp(),
+            "expiresAt" to Timestamp(Date(System.currentTimeMillis() + TTL_MS)),
+        )
+        sample.accuracy?.let { data["accuracy"] = it }
+        sample.heading?.let { data["heading"] = it }
+        sample.speed?.let { data["speed"] = it }
+
+        docRef(config).set(data, SetOptions.merge())
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { err ->
+                Log.w(TAG, "live-location write failed", err); onFailure(err)
+            }
+    }
+
+    override fun deleteDoc(
+        config: LiveLocationConfig,
+        onSuccess: () -> Unit,
+        onFailure: (Throwable) -> Unit,
+    ) {
+        docRef(config).delete()
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { err ->
+                Log.w(TAG, "live-location delete failed", err); onFailure(err)
+            }
+    }
+
+    private fun docRef(config: LiveLocationConfig) =
+        firestore.collection("call").document(config.firecallId)
+            .collection("livelocation").document(config.uid)
+}

--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/livelocation/LiveLocationPusher.kt
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/livelocation/LiveLocationPusher.kt
@@ -1,0 +1,85 @@
+package at.ffnd.einsatzkarte.livelocation
+
+import at.ffnd.einsatzkarte.radiacode.track.Haversine
+
+/**
+ * Drosselt GPS-Updates per OR-Schwellwert (Zeit ODER Distanz) und schreibt
+ * jeweils das Live-Location-Dokument. Single-in-flight: solange das letzte
+ * `writeSample()` läuft, werden weitere Sample-Calls verworfen — derselbe
+ * Pattern wie [at.ffnd.einsatzkarte.gpstrack.GpsTrackRecorder].
+ *
+ * Thread-Kontrakt: `onLocation()`, `updateSettings()` und `stop()` müssen
+ * vom selben Thread aufgerufen werden (Service-Main-Looper). `@Volatile`
+ * sorgt für Cross-Thread-Sichtbarkeit, ersetzt aber keine Synchronisation
+ * bei konkurrenten Aufrufen.
+ *
+ * Heartbeat: damit das Dokument nicht unter die TTL läuft, während der
+ * Nutzer steht und kein neuer Fix kommt, sorgt das `intervalMs` als
+ * Max-Wartezeit für ein Update — und der allererste Fix nach `start` wird
+ * immer geschrieben.
+ */
+class LiveLocationPusher(
+    private val config: LiveLocationConfig,
+    private val sink: LiveLocationDocSink,
+    intervalMs: Long,
+    distanceM: Double,
+    private val nowMs: () -> Long = System::currentTimeMillis,
+) {
+    private data class Last(val lat: Double, val lng: Double, val time: Long)
+
+    @Volatile private var last: Last? = null
+    @Volatile private var stopped = false
+    @Volatile private var writeInFlight = false
+
+    @Volatile private var intervalMs: Long = intervalMs.coerceAtLeast(1_000L)
+    @Volatile private var distanceM: Double = distanceM.coerceAtLeast(0.0)
+
+    fun updateSettings(newIntervalMs: Long, newDistanceM: Double) {
+        intervalMs = newIntervalMs.coerceAtLeast(1_000L)
+        distanceM = newDistanceM.coerceAtLeast(0.0)
+    }
+
+    fun onLocation(
+        lat: Double,
+        lng: Double,
+        accuracy: Double? = null,
+        heading: Double? = null,
+        speed: Double? = null,
+    ) {
+        if (stopped) return
+        if (!lat.isFinite() || !lng.isFinite()) return
+        if (writeInFlight) return
+        val now = nowMs()
+        val l = last
+        val shouldWrite = if (l == null) {
+            true
+        } else {
+            val dist = Haversine.distanceMeters(l.lat, l.lng, lat, lng)
+            val dt = now - l.time
+            dt >= intervalMs || dist >= distanceM
+        }
+        if (!shouldWrite) return
+        last = Last(lat, lng, now)
+        writeInFlight = true
+        sink.writeSample(
+            config,
+            LiveLocationSample(lat, lng, accuracy, heading, speed),
+            onSuccess = { writeInFlight = false },
+            onFailure = { writeInFlight = false },
+        )
+    }
+
+    fun stop() {
+        stopped = true
+    }
+
+    /**
+     * Best-effort delete des Live-Location-Dokuments. Wird typischerweise
+     * von außen direkt nach [stop] aufgerufen, damit der Nutzer nach dem
+     * Beenden des Sharings nicht noch eine Stunde lang als „live" auf der
+     * Karte erscheint (TTL übernimmt sonst nach 1 h).
+     */
+    fun deleteDoc() {
+        sink.deleteDoc(config)
+    }
+}

--- a/docs/plans/2026-05-07-live-location-sharing-design.md
+++ b/docs/plans/2026-05-07-live-location-sharing-design.md
@@ -1,0 +1,204 @@
+# Live-Standort-Sharing — Design
+
+**Datum:** 2026-05-07
+**Branch:** `feature/live-location`
+**Status:** Approved
+
+## Ziel
+
+Einsatzkräfte sollen ihren Live-Standort innerhalb eines aktiven Firecalls für andere Einsatz-Berechtigte freigeben können. Andere User sehen die Standorte als Avatar-Marker auf der Einsatzkarte. Das Feature funktioniert in Browser und nativer Android-App (mit Foreground Service für Background-Betrieb).
+
+## Entscheidungen aus Brainstorming
+
+| Punkt | Entscheidung |
+|---|---|
+| UI-Einstiegspunkt | Eigener FAB über dem `RecordButton` |
+| Aktivierungs-Flow | Bestätigungs-Dialog mit Defaults sichtbar + ausklappbare „Erweiterte Einstellungen" |
+| Auto-Stop | Sharing ist an aktiven Firecall gebunden; bei Wechsel/Verlassen → Stop + Doc-Delete. Native: Background läuft weiter, solange Firecall aktiv |
+| Reziprozität | Keine — jeder mit Firecall-Zugriff sieht alle Live-Standorte |
+| Defaults | Heartbeat 30 s, Distanz-Schwelle 20 m, OR-Logik |
+| Marker | Avatar mit Initialen + permanentes Namens-Label, kein Genauigkeits-Kreis, eigene Leaflet-Layer |
+| Eigener Marker | Bleibt der bestehende `PositionMarker`; eigene UID wird aus Live-Layer gefiltert |
+| Frische | Soft-Fade ab 2 min, hart-cutoff bei 5 min |
+| Native Android | Foreground Service mit Notification, integriert in bestehenden GPS-Track-Service, beide Modi unabhängig |
+| Notification-Inhalt | Modus + Firecall-Name |
+| Reboot-Verhalten | Sharing wird nicht automatisch wieder gestartet |
+| Settings-Persistenz | localStorage, geräte-lokal |
+| Marker-Tap | Popup mit Name + „zuletzt aktualisiert vor X min" |
+| Stale-Cleanup | Firestore TTL Policy auf `expiresAt` (1 h nach letztem Update) |
+| Audit-Log | Kein Eintrag pro Start/Stop |
+
+## Architektur & Komponenten
+
+### Neue Dateien
+
+- `src/components/providers/LiveLocationProvider.tsx` — Context-Provider mit `isSharing`, `settings`, `start()`, `stop()`, `permissionState`. Eingehängt im Einsatz-Layout.
+- `src/hooks/useLiveLocationShare.ts` — Schreib-Logik. Konsumiert `usePosition`, throttled per OR-Logik (≥30 s ODER ≥20 m), schreibt Firestore-Doc, ruft Native-Bridge.
+- `src/hooks/useLiveLocations.ts` — Lese-Logik. Subscribed via `useFirebaseCollection` auf `call/{firecallId}/livelocation`, filtert clientseitig Docs > 5 min und eigene UID raus.
+- `src/hooks/useLiveLocationSettings.ts` — Persistiert `{ heartbeatMs, distanceM }` in `localStorage` mit Defaults und Validierung.
+- `src/components/LiveLocation/LiveLocationFab.tsx` — FAB mit drei Zuständen (off, aktiv, Fehler/Permission verweigert).
+- `src/components/LiveLocation/LiveLocationDialog.tsx` — Start-Bestätigungs-Dialog mit ausklappbaren Slidern für Heartbeat-Intervall und Distanz-Schwelle.
+- `src/components/LiveLocation/LiveLocationStopConfirm.tsx` — kleiner Bestätigungs-Dialog/Snackbar zum Stoppen.
+- `src/components/Map/layers/LiveLocationLayer.tsx` — Leaflet `LayerGroup`, rendert alle anderen User-Marker, berechnet Opacity über die Zeit.
+- `src/components/Map/markers/LiveLocationMarker.tsx` — Avatar (Initialen + deterministische Farbe) + permanentes Namens-Label als Leaflet `divIcon`. Popup mit Name + relativer Zeit.
+- `src/common/liveLocation.ts` — Type-Definition `LiveLocation`, Initialen- und Farb-Helper, Konstanten.
+
+### Geänderte Dateien
+
+- [src/components/Map/Map.tsx](../../src/components/Map/Map.tsx) — neuer `LayersControl.Overlay` „Live-Standorte" mit `LiveLocationLayer`, defaultmäßig eingeschaltet.
+- [src/components/Map/RecordButton.tsx](../../src/components/Map/RecordButton.tsx) — `LiveLocationFab` darüber positionieren (gemeinsamer FAB-Stack).
+- [src/hooks/recording/nativeGpsTrackBridge.ts](../../src/hooks/recording/nativeGpsTrackBridge.ts) — erweitert um `nativeStartLiveShare`, `nativeStopLiveShare`, `nativeUpdateLiveShareSettings`.
+- Capacitor-Native-Code unter [capacitor/android/app/src/main/java/...](../../capacitor/android/app/src/main/java/) — Foreground-Service mit unabhängigen Modus-Flags `track` und `liveShare`. Notification-Text wird kontextabhängig zusammengesetzt.
+- [firebase/dev/firestore.rules](../../firebase/dev/firestore.rules) und Prod-Pendant — neue Regeln für `livelocation`.
+- Firecall-Layout (z.B. `src/app/einsatz/[firecallId]/layout.tsx` oder vergleichbarer Provider-Wrapper) — `LiveLocationProvider` einhängen.
+
+## Datenmodell
+
+**Collection:** `call/{firecallId}/livelocation/{uid}` — eine Doc pro User pro Firecall, Doc-ID = User-UID.
+
+```ts
+interface LiveLocation {
+  uid: string;
+  name: string;            // displayName, Fallback: email
+  email: string;           // immer gefüllt
+  lat: number;
+  lng: number;
+  accuracy?: number;       // gespeichert, aber nicht angezeigt
+  heading?: number;
+  speed?: number;
+  updatedAt: Timestamp;    // serverTimestamp()
+  expiresAt: Timestamp;    // updatedAt + 1h, für Firestore TTL
+}
+```
+
+**Firestore TTL Policy** auf Feld `expiresAt` aktivieren (Cloud Console / `gcloud firestore fields ttls update`).
+
+## Security Rules
+
+```
+match /call/{firecallId}/livelocation/{userId} {
+  allow read:   if callAuthorized(firecallId);
+  allow create: if callAuthorized(firecallId)
+                && userId == request.auth.uid
+                && request.resource.data.uid == request.auth.uid;
+  allow update: if callAuthorized(firecallId)
+                && userId == request.auth.uid
+                && request.resource.data.uid == request.auth.uid;
+  allow delete: if callAuthorized(firecallId)
+                && userId == request.auth.uid;
+}
+```
+
+Diese Regel überschreibt das generische `match /{subitem=**}` für die `livelocation`-Subcollection, damit Schreibzugriff strikt auf die eigene UID begrenzt ist. Lesezugriff bleibt für alle Firecall-berechtigten User offen.
+
+## UI-Flow
+
+### FAB-Zustände
+
+| Zustand | Icon | Farbe | Tap |
+|---|---|---|---|
+| Off | `LocationOnOutlined` | default | öffnet Start-Dialog |
+| Aktiv | `LocationOn` (gefüllt) | primary, leichtes Pulsieren | öffnet Stop-Confirm |
+| Fehler / Permission verweigert | `LocationOff` | error | Snackbar/Dialog mit Hinweis |
+
+FAB ist nur sichtbar, wenn der User in einem aktiven Firecall ist und `usePosition` mindestens einmal eine Position geliefert hat (Permission `granted`).
+
+### Start-Dialog
+
+```
+Standort teilen?
+─────────────────────────
+Dein Live-Standort wird für andere Einsatzkräfte
+im Einsatz "<Firecall-Name>" sichtbar.
+
+▾ Erweiterte Einstellungen
+   Heartbeat-Intervall: 30 s   [Slider 10–120 s]
+   Distanz-Schwelle:    20 m   [Slider 5–100 m]
+
+[Abbrechen]            [Standort teilen]
+```
+
+Werte werden aus `localStorage` vorbelegt; bei Änderung wieder dort gespeichert.
+
+### Stop-Flow
+
+Tap auf aktiven FAB → Bestätigungs-Dialog „Live-Sharing beenden?". Bei Bestätigung:
+
+1. Lokales Tracking stoppt.
+2. Native-Service-Modus `liveShare` deaktiviert (Service stoppt komplett, wenn auch `track` off).
+3. Firestore-Doc wird gelöscht.
+
+### Layer-Anzeige
+
+- Eigener Layer in `LayersControl.Overlay` „Live-Standorte" — defaultmäßig **eingeschaltet**.
+- Marker = Leaflet `divIcon` mit kreisförmigem Avatar (Initialen, deterministischer Hintergrund aus UID-Hash) und Namens-Label permanent rechts daneben.
+- Klick auf Marker → Leaflet-Popup mit Name + „zuletzt aktualisiert vor X min" (live updaten via `Intl.RelativeTimeFormat`).
+- Frische-Verlauf clientseitig: `0–2 min → opacity 1.0`, `2–5 min → linear 1.0 → 0.3`, `> 5 min → ausgeblendet`.
+- Eigene UID wird aus dem Render gefiltert; eigener `PositionMarker` bleibt davon unabhängig.
+
+## Native Android & Lifecycle
+
+### Bridge-Erweiterung
+
+```ts
+// src/hooks/recording/nativeGpsTrackBridge.ts
+nativeStartLiveShare({ firecallId, uid, name, email, intervalMs, distanceM, firecallName })
+nativeStopLiveShare()
+nativeUpdateLiveShareSettings({ intervalMs, distanceM })
+```
+
+### Foreground Service
+
+Track-Recording und Live-Share laufen unabhängig im selben Service. Beide haben eigene Modus-Flags. Notification-Text wird kontextabhängig zusammengesetzt:
+
+- Nur Track: „Einsatz wird aufgezeichnet — <Firecall-Name>"
+- Nur Live-Share: „Live-Standort wird geteilt — <Firecall-Name>"
+- Beides: „Standort wird aufgezeichnet & geteilt — <Firecall-Name>"
+
+Service stoppt automatisch, sobald **beide** Modi off sind.
+
+### Auto-Stop-Bedingungen
+
+1. User tippt FAB → explizit stoppen.
+2. Aktiver Firecall ändert sich → automatisch stoppen + alten Doc löschen.
+3. Browser: Page unmount / `beforeunload` → Best-Effort Doc-Delete (z.B. Server Action mit `keepalive`-Fetch).
+4. Native Android: Reboot → kein Auto-Restart.
+5. Permission revoked / GPS deaktiviert → stoppen, FAB zeigt Fehler-Zustand.
+
+### Robustheit
+
+Wenn Browser-Tab crasht ohne Doc-Delete → Doc bleibt liegen, wird durch `expiresAt`-TTL nach 1 h aufgeräumt. UI zeigt es bereits nach 5 min nicht mehr an.
+
+## Edge Cases
+
+- **Initialen:** erste Buchstaben der ersten zwei Wörter aus `name`; Fallback erste 2 Zeichen der Email vor `@`.
+- **Avatar-Farbe:** Deterministisch aus `uid`-Hash modulo Palette (~12 gut unterscheidbare Farben).
+- **Name-Quelle:** `displayName ?? email`. Beim Schreiben einmalig im Doc gespeichert, kein Live-Lookup beim Marker-Render.
+- **Mehrere Tabs / Geräte gleichzeitig:** Doc wird per UID überschrieben → letzter Schreibender gewinnt. Akzeptabel.
+- **Settings-Defaults:** Konstanten in `useLiveLocationSettings.ts`: `DEFAULT_HEARTBEAT_MS = 30000`, `DEFAULT_DISTANCE_M = 20`. Slider-Range 10–120 s und 5–100 m.
+
+## Tests (TDD)
+
+Pro Modul Tests neben dem Source (`*.test.ts(x)`):
+
+- `useLiveLocationShare.test.ts` — OR-Throttling: send bei 30 s ohne Bewegung, kein doppelter Send vor 30 s ohne Distanz, send bei ≥20 m vor 30 s, Auto-Stop bei Firecall-Wechsel.
+- `useLiveLocations.test.ts` — Filterung > 5 min, Filterung eigener UID, Reaktion auf neue/entfernte Docs.
+- `useLiveLocationSettings.test.ts` — Persistenz, Defaults, Slider-Grenzen-Validierung.
+- `LiveLocationDialog.test.tsx` — Default-Werte angezeigt, Erweitert ausklappbar, Submit ruft `start()` mit aktuellen Werten.
+- `LiveLocationLayer.test.tsx` — rendert nur fremde User, Opacity-Berechnung über die Zeit (Vitest Fake Timers).
+- `LiveLocationMarker.test.tsx` — Initialen-Berechnung, Farb-Hash deterministisch, Popup-Inhalt mit relativer Zeit.
+- Security Rules: falls `@firebase/rules-unit-testing` verfügbar, Tests für Eigen-Schreib-Zugriff und allgemeinen Lese-Zugriff.
+- Manuelle Verifikation: Browser + Native Android, Permissions-Flow, Auto-Stopp bei Firecall-Wechsel, Notification-Text in allen Modus-Kombinationen.
+
+## Build-Sequenz
+
+1. Datenmodell: Type, Konstanten, Helper, Firestore Rules + TTL Policy.
+2. `useLiveLocationSettings` (localStorage).
+3. `useLiveLocationShare` (OR-Throttling, ohne Native).
+4. `LiveLocationProvider`.
+5. `useLiveLocations` Read-Hook + `LiveLocationLayer` + `LiveLocationMarker`.
+6. `LiveLocationFab` + `LiveLocationDialog` + `LiveLocationStopConfirm` (UI-Aktivierung im Browser).
+7. Auto-Stop-Lifecycle (Firecall-Wechsel, Page-Unmount).
+8. Native-Bridge + Capacitor Foreground-Service-Erweiterung.
+9. Manuelle Tests Browser + Native.
+10. PR.

--- a/docs/plans/2026-05-07-live-location-sharing-plan.md
+++ b/docs/plans/2026-05-07-live-location-sharing-plan.md
@@ -1,0 +1,1170 @@
+# Live-Standort-Sharing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** User können ihren Live-Standort innerhalb eines Firecalls für andere sichtbar machen. Andere User sehen die Standorte als Avatar-Marker auf der Einsatzkarte. Funktioniert in Browser und nativer Android-App (Foreground Service).
+
+**Architecture:** Firestore-Subcollection `call/{firecallId}/livelocation/{uid}` mit TTL-Cleanup. Schreib-Logik in `useLiveLocationShare` mit OR-Throttling (30 s ODER 20 m). Lese-Logik in eigener Leaflet-LayerGroup. Native Android: Bridge-Erweiterung für bestehenden Foreground Service mit unabhängigen Modi `track` und `liveShare`.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Firebase Firestore, MUI, Leaflet/React Leaflet, Capacitor 8 + Kotlin/Java für Android.
+
+**Wichtig (User-Memory):** Im hydranten-map-Projekt **keine Zwischen-Commits/Checks pro Step**. Checks (`npx tsc --noEmit`, `npx eslint`, `npx vitest run`, `npx next build --webpack`) und Commit am Ende — siehe Task 11.
+
+**Reference docs:**
+- Design: `docs/plans/2026-05-07-live-location-sharing-design.md`
+- CLAUDE.md (Worktree-Root)
+
+---
+
+## Task 1: Datenmodell, Konstanten & Helper
+
+**Files:**
+- Create: `src/common/liveLocation.ts`
+- Create: `src/common/liveLocation.test.ts`
+
+**Step 1: Tests schreiben** (`liveLocation.test.ts`)
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  computeInitials,
+  pickAvatarColor,
+  isFresh,
+  computeOpacity,
+  LIVE_LOCATION_COLLECTION_ID,
+  STALE_HARD_CUTOFF_MS,
+  STALE_FADE_START_MS,
+} from './liveLocation';
+
+describe('liveLocation helpers', () => {
+  describe('computeInitials', () => {
+    it('takes first letter of first two words', () => {
+      expect(computeInitials('Paul Wölfel', 'paul@x.at')).toBe('PW');
+    });
+    it('falls back to single first letter for one-word names', () => {
+      expect(computeInitials('Paul', 'paul@x.at')).toBe('P');
+    });
+    it('uses first 2 chars of email local part when name is empty', () => {
+      expect(computeInitials('', 'paul.woelfel@example.com')).toBe('PA');
+    });
+    it('returns ?? when neither name nor email usable', () => {
+      expect(computeInitials('', '')).toBe('??');
+    });
+  });
+
+  describe('pickAvatarColor', () => {
+    it('is deterministic for same uid', () => {
+      expect(pickAvatarColor('uid-1')).toBe(pickAvatarColor('uid-1'));
+    });
+    it('returns a valid hex color', () => {
+      expect(pickAvatarColor('uid-1')).toMatch(/^#[0-9a-f]{6}$/i);
+    });
+    it('returns one of the palette colors', () => {
+      const c = pickAvatarColor('any-uid');
+      // not all uids must hit different colors, but the result must be from the palette
+      expect(typeof c).toBe('string');
+      expect(c.length).toBe(7);
+    });
+  });
+
+  describe('isFresh / computeOpacity', () => {
+    const now = 1_700_000_000_000;
+    it('returns true when within hard cutoff', () => {
+      expect(isFresh(now - 4 * 60_000, now)).toBe(true);
+    });
+    it('returns false past hard cutoff', () => {
+      expect(isFresh(now - 6 * 60_000, now)).toBe(false);
+    });
+    it('opacity is 1 below fade start', () => {
+      expect(computeOpacity(now - 1 * 60_000, now)).toBe(1);
+    });
+    it('opacity is 0 past hard cutoff', () => {
+      expect(computeOpacity(now - 6 * 60_000, now)).toBe(0);
+    });
+    it('opacity scales linearly between fade start and cutoff', () => {
+      const mid = now - ((STALE_FADE_START_MS + STALE_HARD_CUTOFF_MS) / 2);
+      const v = computeOpacity(mid, now);
+      expect(v).toBeGreaterThan(0.3);
+      expect(v).toBeLessThan(1);
+    });
+  });
+
+  it('exposes the collection id constant', () => {
+    expect(LIVE_LOCATION_COLLECTION_ID).toBe('livelocation');
+  });
+});
+```
+
+**Step 2: Implementation** (`liveLocation.ts`)
+
+```ts
+import { Timestamp } from 'firebase/firestore';
+
+export const LIVE_LOCATION_COLLECTION_ID = 'livelocation';
+
+export const STALE_FADE_START_MS = 2 * 60 * 1000;     // 2 min
+export const STALE_HARD_CUTOFF_MS = 5 * 60 * 1000;    // 5 min
+export const TTL_EXPIRY_MS = 60 * 60 * 1000;          // 1 h (Firestore TTL)
+
+export interface LiveLocation {
+  uid: string;
+  name: string;
+  email: string;
+  lat: number;
+  lng: number;
+  accuracy?: number;
+  heading?: number;
+  speed?: number;
+  updatedAt: Timestamp;
+  expiresAt: Timestamp;
+}
+
+const PALETTE = [
+  '#1976d2', '#388e3c', '#d32f2f', '#f57c00',
+  '#7b1fa2', '#0288d1', '#c2185b', '#5d4037',
+  '#00796b', '#fbc02d', '#512da8', '#455a64',
+];
+
+export function pickAvatarColor(uid: string): string {
+  let hash = 0;
+  for (let i = 0; i < uid.length; i++) {
+    hash = (hash * 31 + uid.charCodeAt(i)) | 0;
+  }
+  const idx = Math.abs(hash) % PALETTE.length;
+  return PALETTE[idx];
+}
+
+export function computeInitials(name: string, email: string): string {
+  const trimmed = name.trim();
+  if (trimmed) {
+    const parts = trimmed.split(/\s+/).filter(Boolean);
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[1][0]).toUpperCase();
+    }
+    return parts[0][0]?.toUpperCase() ?? '?';
+  }
+  const local = (email.split('@')[0] || '').trim();
+  if (local) {
+    return local.slice(0, 2).toUpperCase();
+  }
+  return '??';
+}
+
+export function isFresh(updatedAtMs: number, nowMs: number = Date.now()): boolean {
+  return nowMs - updatedAtMs < STALE_HARD_CUTOFF_MS;
+}
+
+export function computeOpacity(
+  updatedAtMs: number,
+  nowMs: number = Date.now()
+): number {
+  const age = nowMs - updatedAtMs;
+  if (age <= STALE_FADE_START_MS) return 1;
+  if (age >= STALE_HARD_CUTOFF_MS) return 0;
+  const fadeRange = STALE_HARD_CUTOFF_MS - STALE_FADE_START_MS;
+  const fadeProgress = (age - STALE_FADE_START_MS) / fadeRange;
+  return 1 - fadeProgress * 0.7;  // 1.0 → 0.3 over fade range
+}
+```
+
+**Verification:** `npx vitest run src/common/liveLocation.test.ts` — alle Tests grün.
+
+---
+
+## Task 2: Firestore Security Rules + TTL Policy
+
+**Files:**
+- Modify: `firebase/dev/firestore.rules`
+- Modify: `firebase/prod/firestore.rules` (falls vorhanden — sonst nur dev)
+
+**Step 1:** Innerhalb des `match /call/{doc}`-Blocks, **vor** dem generischen `match /{subitem=**}`, neue Regel einfügen:
+
+```
+match /livelocation/{userId} {
+  allow read:   if callAuthorized();
+  allow create: if callAuthorized()
+                && userId == request.auth.uid
+                && request.resource.data.uid == request.auth.uid;
+  allow update: if callAuthorized()
+                && userId == request.auth.uid
+                && request.resource.data.uid == request.auth.uid;
+  allow delete: if callAuthorized()
+                && userId == request.auth.uid;
+}
+```
+
+**Step 2:** Identische Regel in `firebase/prod/firestore.rules` einfügen, falls die Datei existiert. Pfad prüfen: `ls firebase/prod/firestore.rules 2>/dev/null`.
+
+**Step 3:** TTL Policy aktivieren — **manueller Schritt** für den User. Im Plan dokumentieren als Hinweis:
+
+> **Manueller Deployment-Schritt (nach Merge):** TTL Policy auf `expiresAt` aktivieren via Cloud Console oder:
+> ```bash
+> gcloud firestore fields ttls update expiresAt \
+>   --collection-group=livelocation --enable-ttl
+> ```
+> Für dev (`ffndev`) und prod separat ausführen.
+
+**Verification:** Rules-Datei syntaktisch prüfen, falls Firebase CLI verfügbar:
+
+```bash
+npx firebase --project ffndev firestore:rules:get  # nur Sanity-Check der bestehenden Rules
+```
+
+(Keine automatische Rules-Tests — manuell via Emulator oder Live-Test in Task 11.)
+
+---
+
+## Task 3: Settings-Hook (`useLiveLocationSettings`)
+
+**Files:**
+- Create: `src/hooks/useLiveLocationSettings.ts`
+- Create: `src/hooks/useLiveLocationSettings.test.ts`
+
+**Step 1: Tests** — persistiert Defaults bei leerem Storage, lädt gespeicherte Werte, klemmt Werte an Min/Max.
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useLiveLocationSettings,
+  DEFAULT_HEARTBEAT_MS,
+  DEFAULT_DISTANCE_M,
+  HEARTBEAT_MIN_MS,
+  HEARTBEAT_MAX_MS,
+  DISTANCE_MIN_M,
+  DISTANCE_MAX_M,
+  STORAGE_KEY,
+} from './useLiveLocationSettings';
+
+describe('useLiveLocationSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns defaults when nothing in storage', () => {
+    const { result } = renderHook(() => useLiveLocationSettings());
+    expect(result.current.settings.heartbeatMs).toBe(DEFAULT_HEARTBEAT_MS);
+    expect(result.current.settings.distanceM).toBe(DEFAULT_DISTANCE_M);
+  });
+
+  it('loads saved settings', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ heartbeatMs: 60_000, distanceM: 50 })
+    );
+    const { result } = renderHook(() => useLiveLocationSettings());
+    expect(result.current.settings.heartbeatMs).toBe(60_000);
+    expect(result.current.settings.distanceM).toBe(50);
+  });
+
+  it('clamps out-of-range values to min/max on save', () => {
+    const { result } = renderHook(() => useLiveLocationSettings());
+    act(() => {
+      result.current.setSettings({ heartbeatMs: 5_000, distanceM: 1_000 });
+    });
+    expect(result.current.settings.heartbeatMs).toBe(HEARTBEAT_MIN_MS);
+    expect(result.current.settings.distanceM).toBe(DISTANCE_MAX_M);
+  });
+
+  it('persists changes to localStorage', () => {
+    const { result } = renderHook(() => useLiveLocationSettings());
+    act(() => {
+      result.current.setSettings({ heartbeatMs: 45_000, distanceM: 25 });
+    });
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.heartbeatMs).toBe(45_000);
+    expect(parsed.distanceM).toBe(25);
+  });
+});
+```
+
+**Step 2: Implementation**
+
+```ts
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+
+export const STORAGE_KEY = 'liveLocationSettings/v1';
+
+export const DEFAULT_HEARTBEAT_MS = 30_000;
+export const DEFAULT_DISTANCE_M = 20;
+export const HEARTBEAT_MIN_MS = 10_000;
+export const HEARTBEAT_MAX_MS = 120_000;
+export const DISTANCE_MIN_M = 5;
+export const DISTANCE_MAX_M = 100;
+
+export interface LiveLocationSettings {
+  heartbeatMs: number;
+  distanceM: number;
+}
+
+const DEFAULTS: LiveLocationSettings = {
+  heartbeatMs: DEFAULT_HEARTBEAT_MS,
+  distanceM: DEFAULT_DISTANCE_M,
+};
+
+const clamp = (n: number, min: number, max: number) =>
+  Math.min(Math.max(n, min), max);
+
+function load(): LiveLocationSettings {
+  if (typeof window === 'undefined') return DEFAULTS;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    const parsed = JSON.parse(raw) as Partial<LiveLocationSettings>;
+    return {
+      heartbeatMs: clamp(
+        Number(parsed.heartbeatMs ?? DEFAULT_HEARTBEAT_MS),
+        HEARTBEAT_MIN_MS,
+        HEARTBEAT_MAX_MS
+      ),
+      distanceM: clamp(
+        Number(parsed.distanceM ?? DEFAULT_DISTANCE_M),
+        DISTANCE_MIN_M,
+        DISTANCE_MAX_M
+      ),
+    };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function useLiveLocationSettings() {
+  const [settings, setSettingsState] = useState<LiveLocationSettings>(load);
+
+  useEffect(() => {
+    setSettingsState(load());
+  }, []);
+
+  const setSettings = useCallback((next: LiveLocationSettings) => {
+    const clamped: LiveLocationSettings = {
+      heartbeatMs: clamp(next.heartbeatMs, HEARTBEAT_MIN_MS, HEARTBEAT_MAX_MS),
+      distanceM: clamp(next.distanceM, DISTANCE_MIN_M, DISTANCE_MAX_M),
+    };
+    setSettingsState(clamped);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(clamped));
+    }
+  }, []);
+
+  return { settings, setSettings };
+}
+```
+
+**Verification:** `npx vitest run src/hooks/useLiveLocationSettings.test.ts`.
+
+---
+
+## Task 4: Schreib-Hook (`useLiveLocationShare`) mit OR-Throttling
+
+**Files:**
+- Create: `src/hooks/useLiveLocationShare.ts`
+- Create: `src/hooks/useLiveLocationShare.test.ts`
+
+**Step 1: Tests** — fokussiert auf reine Throttle-Logik. Ziehe die Pure-Funktion `shouldSendUpdate(lastSent, now, lastPos, currentPos, settings)` aus dem Hook heraus, damit sie ohne React getestet werden kann.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { shouldSendUpdate, distanceMeters } from './useLiveLocationShare';
+
+const settings = { heartbeatMs: 30_000, distanceM: 20 };
+
+describe('shouldSendUpdate (OR logic)', () => {
+  it('triggers on first call (no lastSent)', () => {
+    expect(
+      shouldSendUpdate(undefined, 1_000, undefined, { lat: 0, lng: 0 }, settings)
+    ).toBe(true);
+  });
+
+  it('triggers when heartbeat elapsed without movement', () => {
+    expect(
+      shouldSendUpdate(0, 30_001, { lat: 0, lng: 0 }, { lat: 0, lng: 0 }, settings)
+    ).toBe(true);
+  });
+
+  it('does not trigger before heartbeat without movement', () => {
+    expect(
+      shouldSendUpdate(0, 29_000, { lat: 0, lng: 0 }, { lat: 0, lng: 0 }, settings)
+    ).toBe(false);
+  });
+
+  it('triggers on distance threshold even before heartbeat', () => {
+    // 0.0002 deg lat ≈ 22 m
+    expect(
+      shouldSendUpdate(
+        0,
+        5_000,
+        { lat: 0, lng: 0 },
+        { lat: 0.0002, lng: 0 },
+        settings
+      )
+    ).toBe(true);
+  });
+
+  it('does not trigger on small movement before heartbeat', () => {
+    // 0.00005 deg lat ≈ 5.5 m
+    expect(
+      shouldSendUpdate(
+        0,
+        5_000,
+        { lat: 0, lng: 0 },
+        { lat: 0.00005, lng: 0 },
+        settings
+      )
+    ).toBe(false);
+  });
+});
+
+describe('distanceMeters', () => {
+  it('is roughly 0 for identical coords', () => {
+    expect(distanceMeters({ lat: 47, lng: 16 }, { lat: 47, lng: 16 }))
+      .toBeLessThan(0.5);
+  });
+  it('approximates 1 deg lat ≈ 111 km', () => {
+    const d = distanceMeters({ lat: 47, lng: 16 }, { lat: 48, lng: 16 });
+    expect(d).toBeGreaterThan(110_000);
+    expect(d).toBeLessThan(112_000);
+  });
+});
+```
+
+**Step 2: Implementation**
+
+```ts
+'use client';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+} from 'firebase/firestore';
+import { useCallback, useEffect, useRef } from 'react';
+import { firestore } from '../components/firebase/firebase';
+import { FIRECALL_COLLECTION_ID } from '../components/firebase/firestore';
+import {
+  LIVE_LOCATION_COLLECTION_ID,
+  TTL_EXPIRY_MS,
+} from '../common/liveLocation';
+import type { LiveLocationSettings } from './useLiveLocationSettings';
+import type { GeoPositionObject } from '../common/geo';
+
+interface ShareIdentity {
+  firecallId: string;
+  uid: string;
+  name: string;
+  email: string;
+}
+
+export function distanceMeters(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): number {
+  const R = 6_371_000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const x =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(x));
+}
+
+export function shouldSendUpdate(
+  lastSentMs: number | undefined,
+  nowMs: number,
+  lastPos: { lat: number; lng: number } | undefined,
+  currentPos: { lat: number; lng: number },
+  settings: LiveLocationSettings
+): boolean {
+  if (lastSentMs === undefined || !lastPos) return true;
+  const elapsed = nowMs - lastSentMs;
+  if (elapsed >= settings.heartbeatMs) return true;
+  if (distanceMeters(lastPos, currentPos) >= settings.distanceM) return true;
+  return false;
+}
+
+export interface LiveLocationShareApi {
+  /** Push a fresh position if the throttle gate allows. */
+  maybeSend: (
+    pos: GeoPositionObject,
+    location: GeolocationPosition | undefined
+  ) => Promise<void>;
+  /** Delete the user's doc (called on stop / firecall change). */
+  deleteOwn: () => Promise<void>;
+}
+
+export function useLiveLocationShare(
+  identity: ShareIdentity | null,
+  settings: LiveLocationSettings
+): LiveLocationShareApi {
+  const lastSentMsRef = useRef<number | undefined>(undefined);
+  const lastPosRef = useRef<{ lat: number; lng: number } | undefined>(undefined);
+
+  const maybeSend = useCallback<LiveLocationShareApi['maybeSend']>(
+    async (pos, location) => {
+      if (!identity) return;
+      const now = Date.now();
+      if (
+        !shouldSendUpdate(
+          lastSentMsRef.current,
+          now,
+          lastPosRef.current,
+          { lat: pos.lat, lng: pos.lng },
+          settings
+        )
+      ) {
+        return;
+      }
+      const ref = doc(
+        firestore,
+        FIRECALL_COLLECTION_ID,
+        identity.firecallId,
+        LIVE_LOCATION_COLLECTION_ID,
+        identity.uid
+      );
+      await setDoc(ref, {
+        uid: identity.uid,
+        name: identity.name,
+        email: identity.email,
+        lat: pos.lat,
+        lng: pos.lng,
+        accuracy: location?.coords.accuracy,
+        heading: location?.coords.heading ?? undefined,
+        speed: location?.coords.speed ?? undefined,
+        updatedAt: serverTimestamp(),
+        expiresAt: Timestamp.fromMillis(Date.now() + TTL_EXPIRY_MS),
+      });
+      lastSentMsRef.current = now;
+      lastPosRef.current = { lat: pos.lat, lng: pos.lng };
+    },
+    [identity, settings]
+  );
+
+  const deleteOwn = useCallback(async () => {
+    if (!identity) return;
+    const ref = doc(
+      firestore,
+      FIRECALL_COLLECTION_ID,
+      identity.firecallId,
+      LIVE_LOCATION_COLLECTION_ID,
+      identity.uid
+    );
+    await deleteDoc(ref).catch((err) => {
+      console.warn('[liveLocation] deleteOwn failed', err);
+    });
+    lastSentMsRef.current = undefined;
+    lastPosRef.current = undefined;
+  }, [identity]);
+
+  // Reset internal state when identity (firecall/user) changes.
+  useEffect(() => {
+    lastSentMsRef.current = undefined;
+    lastPosRef.current = undefined;
+  }, [identity?.firecallId, identity?.uid]);
+
+  return { maybeSend, deleteOwn };
+}
+```
+
+**Verification:** `npx vitest run src/hooks/useLiveLocationShare.test.ts`.
+
+---
+
+## Task 5: Provider (`LiveLocationProvider`)
+
+**Files:**
+- Create: `src/components/providers/LiveLocationProvider.tsx`
+- Create: `src/components/providers/LiveLocationProvider.test.tsx`
+- Modify: `src/components/providers/AppProviders.tsx` (Provider zwischen `GpsProvider` und `DebugLoggingProvider` einhängen)
+
+**Step 1: Skeleton + Tests**
+
+Provider exposes:
+- `isSharing: boolean`
+- `start(): Promise<void>` — startet Sharing, ruft Native-Bridge falls verfügbar
+- `stop(): Promise<void>` — stoppt + löscht eigenes Doc
+- `settings`, `setSettings` (durchgereicht aus `useLiveLocationSettings`)
+- `permissionState: 'unknown' | 'granted' | 'denied'`
+
+Logik:
+- Konsumiert `usePositionContext`, `useFirebaseLogin`, `useFirecallId`, `useFirecall` (für `firecallName`).
+- Ruft bei jedem Position-Update `maybeSend` auf, solange `isSharing` und Permission ok.
+- Bei Firecall-Wechsel (`firecallId` ändert sich, während aktiv): automatisch stoppen + Doc-Delete (alter Pfad). Anschließend ggf. mit neuem Firecall neu starten lassen — User muss selbst entscheiden, also nur stoppen.
+- Bei Unmount oder `beforeunload`: best-effort Doc-Delete.
+- `start()` ruft `nativeStartLiveShare` falls verfügbar (`isNativeGpsTrackingAvailable`); `stop()` ruft `nativeStopLiveShare`.
+
+Tests (mit Mocks für `firestore`, Native-Bridge): grundlegende Lifecycle-Smoke-Tests:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { LiveLocationProvider, useLiveLocationContext } from './LiveLocationProvider';
+
+vi.mock('../firebase/firebase', () => ({ firestore: {} }));
+vi.mock('../../hooks/recording/nativeGpsTrackBridge', () => ({
+  isNativeGpsTrackingAvailable: () => false,
+  nativeStartLiveShare: vi.fn(),
+  nativeStopLiveShare: vi.fn(),
+}));
+// + minimal mocks für usePositionContext, useFirebaseLogin, useFirecall(Id)
+
+// ... assert that isSharing toggles correctly via start()/stop()
+```
+
+**Step 2: Implementation** — Skeleton:
+
+```tsx
+'use client';
+import React, { createContext, useCallback, useContext, useEffect,
+  useMemo, useRef, useState } from 'react';
+import { useLiveLocationShare } from '../../hooks/useLiveLocationShare';
+import { useLiveLocationSettings, LiveLocationSettings } from '../../hooks/useLiveLocationSettings';
+import { usePositionContext } from './PositionProvider';
+import useFirebaseLogin from '../../hooks/useFirebaseLogin';
+import { useFirecall, useFirecallId } from '../../hooks/useFirecall';
+import {
+  isNativeGpsTrackingAvailable,
+  nativeStartLiveShare,
+  nativeStopLiveShare,
+} from '../../hooks/recording/nativeGpsTrackBridge';
+
+interface LiveLocationContextValue {
+  isSharing: boolean;
+  settings: LiveLocationSettings;
+  setSettings: (s: LiveLocationSettings) => void;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  canShare: boolean;        // position + firecall + uid available
+}
+
+const LiveLocationContext = createContext<LiveLocationContextValue | null>(null);
+
+export function LiveLocationProvider({ children }: { children: React.ReactNode }) {
+  const [position, isPositionSet, location] = usePositionContext();
+  const { uid, email, displayName } = useFirebaseLogin();
+  const firecallId = useFirecallId();
+  const firecall = useFirecall();
+
+  const { settings, setSettings } = useLiveLocationSettings();
+  const [isSharing, setIsSharing] = useState(false);
+
+  const identity = useMemo(() => {
+    if (!isSharing || !uid || !firecallId || firecallId === 'unknown') {
+      return null;
+    }
+    return {
+      firecallId,
+      uid,
+      name: displayName || email || '',
+      email: email ?? '',
+    };
+  }, [isSharing, uid, firecallId, displayName, email]);
+
+  const { maybeSend, deleteOwn } = useLiveLocationShare(identity, settings);
+
+  // Push position updates while sharing
+  useEffect(() => {
+    if (!isSharing || !isPositionSet) return;
+    void maybeSend(position, location);
+  }, [isSharing, isPositionSet, position, location, maybeSend]);
+
+  // Auto-stop on firecall change
+  const previousFirecallRef = useRef(firecallId);
+  useEffect(() => {
+    if (previousFirecallRef.current !== firecallId && isSharing) {
+      // tear down with the OLD firecall id captured by the previous identity
+      void deleteOwn();
+      setIsSharing(false);
+      if (isNativeGpsTrackingAvailable()) {
+        void nativeStopLiveShare().catch(() => {});
+      }
+    }
+    previousFirecallRef.current = firecallId;
+  }, [firecallId, isSharing, deleteOwn]);
+
+  // Best-effort cleanup on unmount + beforeunload
+  useEffect(() => {
+    if (!isSharing) return;
+    const handler = () => { void deleteOwn(); };
+    window.addEventListener('beforeunload', handler);
+    return () => {
+      window.removeEventListener('beforeunload', handler);
+      void deleteOwn();
+    };
+  }, [isSharing, deleteOwn]);
+
+  const start = useCallback(async () => {
+    if (!uid || !firecallId || firecallId === 'unknown') return;
+    setIsSharing(true);
+    if (isNativeGpsTrackingAvailable()) {
+      await nativeStartLiveShare({
+        firecallId,
+        uid,
+        name: displayName || email || '',
+        email: email ?? '',
+        intervalMs: settings.heartbeatMs,
+        distanceM: settings.distanceM,
+        firecallName: firecall.name,
+      }).catch((err) => console.warn('[liveLocation] native start failed', err));
+    }
+  }, [uid, firecallId, displayName, email, settings, firecall.name]);
+
+  const stop = useCallback(async () => {
+    setIsSharing(false);
+    await deleteOwn();
+    if (isNativeGpsTrackingAvailable()) {
+      await nativeStopLiveShare().catch(() => {});
+    }
+  }, [deleteOwn]);
+
+  const canShare = isPositionSet && !!uid && firecallId !== 'unknown';
+
+  const value: LiveLocationContextValue = {
+    isSharing, settings, setSettings, start, stop, canShare,
+  };
+
+  return (
+    <LiveLocationContext.Provider value={value}>
+      {children}
+    </LiveLocationContext.Provider>
+  );
+}
+
+export function useLiveLocationContext(): LiveLocationContextValue {
+  const ctx = useContext(LiveLocationContext);
+  if (!ctx) throw new Error('useLiveLocationContext must be used within LiveLocationProvider');
+  return ctx;
+}
+```
+
+**Step 3: Provider in AppProviders einhängen** — `LiveLocationProvider` direkt **innerhalb** des `GpsProvider` und **außerhalb** des `DebugLoggingProvider` (oder weiter innen, Hauptsache nach `PositionProvider` und `FirecallProvider`):
+
+```tsx
+const LiveLocationProvider = dynamic(() => import('./LiveLocationProvider'), {
+  ssr: false,
+});
+
+// in LogedinApp:
+<GpsProvider>
+  <LiveLocationProvider>
+    <DebugLoggingProvider>
+      ...
+    </DebugLoggingProvider>
+  </LiveLocationProvider>
+</GpsProvider>
+```
+
+**Verification:** `npx vitest run src/components/providers/LiveLocationProvider.test.tsx`.
+
+---
+
+## Task 6: Read-Hook + Layer + Marker
+
+**Files:**
+- Create: `src/hooks/useLiveLocations.ts`
+- Create: `src/hooks/useLiveLocations.test.ts`
+- Create: `src/components/Map/layers/LiveLocationLayer.tsx`
+- Create: `src/components/Map/markers/LiveLocationMarker.tsx`
+- Create: `src/components/Map/markers/LiveLocationMarker.test.tsx`
+- Modify: `src/components/Map/Map.tsx` — neuer `LayersControl.Overlay` „Live-Standorte" mit `LiveLocationLayer`, **defaultmäßig `checked`**, eingefügt direkt nach dem bestehenden `Position`-Overlay.
+
+**Step 1: `useLiveLocations` Hook**
+
+```ts
+'use client';
+import { useMemo } from 'react';
+import useFirebaseCollection from './useFirebaseCollection';
+import { FIRECALL_COLLECTION_ID } from '../components/firebase/firestore';
+import { LIVE_LOCATION_COLLECTION_ID, isFresh, LiveLocation } from '../common/liveLocation';
+import { useFirecallId } from './useFirecall';
+import useFirebaseLogin from './useFirebaseLogin';
+
+export interface DisplayableLiveLocation extends LiveLocation {
+  id: string;
+  /** epoch ms of updatedAt for opacity calc */
+  updatedAtMs: number;
+}
+
+export function useLiveLocations(): DisplayableLiveLocation[] {
+  const firecallId = useFirecallId();
+  const { uid: myUid } = useFirebaseLogin();
+
+  const records = useFirebaseCollection<LiveLocation & { id: string }>({
+    collectionName: FIRECALL_COLLECTION_ID,
+    pathSegments: [firecallId, LIVE_LOCATION_COLLECTION_ID],
+  });
+
+  return useMemo(() => {
+    if (!records) return [];
+    const now = Date.now();
+    return records
+      .filter((r) => r.uid !== myUid)
+      .map((r) => {
+        const ms = r.updatedAt
+          ? // @ts-ignore — Firestore Timestamp duck-typed
+            (typeof r.updatedAt.toMillis === 'function'
+              ? r.updatedAt.toMillis()
+              : 0)
+          : 0;
+        return { ...r, id: r.id, updatedAtMs: ms };
+      })
+      .filter((r) => isFresh(r.updatedAtMs, now));
+  }, [records, myUid]);
+}
+```
+
+Tests prüfen Filter (eigene UID raus, > 5 min raus) per Mocking von `useFirebaseCollection`.
+
+**Step 2: `LiveLocationMarker`** — Leaflet `divIcon` mit Avatar + Label, Popup mit Name + relativer Zeit. Re-render alle 30 s, damit Opacity & Zeit-Label aktualisieren.
+
+```tsx
+'use client';
+import L from 'leaflet';
+import { useEffect, useMemo, useState } from 'react';
+import { Marker, Popup } from 'react-leaflet';
+import {
+  computeInitials,
+  computeOpacity,
+  pickAvatarColor,
+} from '../../../common/liveLocation';
+import type { DisplayableLiveLocation } from '../../../hooks/useLiveLocations';
+
+const formatRelative = (ms: number): string => {
+  const ageSec = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (ageSec < 60) return `vor ${ageSec} s`;
+  const m = Math.round(ageSec / 60);
+  return `vor ${m} min`;
+};
+
+export default function LiveLocationMarker({
+  loc,
+}: {
+  loc: DisplayableLiveLocation;
+}) {
+  const [, force] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => force((n) => n + 1), 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const opacity = computeOpacity(loc.updatedAtMs);
+  const initials = computeInitials(loc.name, loc.email);
+  const color = pickAvatarColor(loc.uid);
+
+  const icon = useMemo(
+    () =>
+      L.divIcon({
+        className: '',
+        html: `
+          <div style="display:flex;align-items:center;gap:4px;opacity:${opacity};pointer-events:auto;">
+            <div style="
+              width:32px;height:32px;border-radius:50%;
+              background:${color};color:#fff;
+              display:flex;align-items:center;justify-content:center;
+              font:bold 12px sans-serif;
+              border:2px solid #fff;box-shadow:0 1px 2px rgba(0,0,0,.4);
+            ">${initials}</div>
+            <div style="
+              background:rgba(255,255,255,.85);
+              padding:2px 6px;border-radius:4px;
+              font:11px sans-serif;color:#222;white-space:nowrap;
+              box-shadow:0 1px 2px rgba(0,0,0,.2);
+            ">${loc.name || loc.email}</div>
+          </div>`,
+        iconSize: [120, 32],
+        iconAnchor: [16, 16],
+        popupAnchor: [0, -16],
+      }),
+    [opacity, initials, color, loc.name, loc.email]
+  );
+
+  if (opacity <= 0) return null;
+
+  return (
+    <Marker position={{ lat: loc.lat, lng: loc.lng }} icon={icon}>
+      <Popup>
+        <strong>{loc.name || loc.email}</strong>
+        <br />
+        zuletzt aktualisiert {formatRelative(loc.updatedAtMs)}
+      </Popup>
+    </Marker>
+  );
+}
+```
+
+Tests (`LiveLocationMarker.test.tsx`): rendert Initialen, Farbe, Popup-Inhalt mit relativer Zeit.
+
+**Step 3: `LiveLocationLayer`** — `LayerGroup`, mappt über `useLiveLocations()`:
+
+```tsx
+'use client';
+import { LayerGroup } from 'react-leaflet';
+import { useLiveLocations } from '../../../hooks/useLiveLocations';
+import LiveLocationMarker from '../markers/LiveLocationMarker';
+
+export default function LiveLocationLayer() {
+  const locations = useLiveLocations();
+  return (
+    <LayerGroup>
+      {locations.map((loc) => (
+        <LiveLocationMarker key={loc.id} loc={loc} />
+      ))}
+    </LayerGroup>
+  );
+}
+```
+
+**Step 4: `Map.tsx` patchen** — nach dem bestehenden `<LayersControl.Overlay name="Position" checked>` Block einfügen:
+
+```tsx
+<LayersControl.Overlay name="Live-Standorte" checked>
+  <LiveLocationLayer />
+</LayersControl.Overlay>
+```
+
+Plus passender Import oben in der Datei.
+
+**Verification:** `npx vitest run src/hooks/useLiveLocations.test.ts src/components/Map/markers/LiveLocationMarker.test.tsx`.
+
+---
+
+## Task 7: FAB + Start-Dialog + Stop-Confirm
+
+**Files:**
+- Create: `src/components/LiveLocation/LiveLocationFab.tsx`
+- Create: `src/components/LiveLocation/LiveLocationDialog.tsx`
+- Create: `src/components/LiveLocation/LiveLocationDialog.test.tsx`
+- Create: `src/components/LiveLocation/LiveLocationStopConfirm.tsx`
+- Modify: `src/components/Map/RecordButton.tsx` — `<LiveLocationFab />` direkt **vor** dem äußeren `<Box>` einfügen, sodass beide FABs nebeneinander auf der Karte erscheinen. Ein zusätzlicher Wrapper ist nicht nötig — `LiveLocationFab` setzt selbst `position: absolute` mit `bottom: 184` (60 px höher als `RecordButton`s 120 px).
+
+**`LiveLocationFab`:**
+
+- Konsumiert `useLiveLocationContext()`.
+- Drei Zustände → drei Icons/Farben:
+  - off + canShare: `<LocationOnOutlined />`, default Farbe → öffnet `LiveLocationDialog`
+  - active: `<LocationOn />`, primary, leichtes CSS-Pulse → öffnet `LiveLocationStopConfirm`
+  - !canShare: gar nicht rendern (vereinfacht; Permission/Firecall fehlt)
+- Tooltip „Live-Standort teilen" / „Live-Sharing läuft".
+
+**`LiveLocationDialog`:**
+
+- MUI `Dialog` mit Titel „Standort teilen?", Body-Text (siehe Design-Doc).
+- `Accordion` „Erweiterte Einstellungen" mit zwei `Slider`-Komponenten.
+- Buttons „Abbrechen" / „Standort teilen".
+- Bei Submit: settings über `setSettings` persistieren (falls geändert), dann `start()` aufrufen.
+
+Tests: render, sliders zeigen aktuelle Werte, Submit ruft `setSettings` und `start`.
+
+**`LiveLocationStopConfirm`:**
+
+- Kleiner MUI `Dialog`: „Live-Sharing beenden?" mit `[Abbrechen] [Beenden]`.
+- Bei Bestätigen: `stop()`.
+
+**Verification:** `npx vitest run src/components/LiveLocation/`.
+
+---
+
+## Task 8: Native Bridge — TypeScript-Seite
+
+**Files:**
+- Modify: `src/hooks/recording/nativeGpsTrackBridge.ts`
+
+Erweitern um Live-Share-Funktionen, die das vorhandene `RadiacodeNotification`-Plugin (= Capacitor-Bridge zum Foreground Service) ansprechen:
+
+```ts
+export interface NativeLiveShareOpts {
+  firecallId: string;
+  uid: string;
+  name: string;
+  email: string;
+  intervalMs: number;
+  distanceM: number;
+  firecallName: string;
+}
+
+export async function nativeStartLiveShare(opts: NativeLiveShareOpts): Promise<void> {
+  console.log('[GpsTrack/native] startLiveShare', opts);
+  // Plugin name & method named consistently with existing API.
+  await GpsTrack.startLiveShare({
+    firecallId: opts.firecallId,
+    uid: opts.uid,
+    name: opts.name,
+    email: opts.email,
+    intervalMs: opts.intervalMs,
+    distanceM: opts.distanceM,
+    firecallName: opts.firecallName,
+    firestoreDb: process.env.NEXT_PUBLIC_FIRESTORE_DB || '(default)',
+  });
+}
+
+export async function nativeStopLiveShare(): Promise<void> {
+  console.log('[GpsTrack/native] stopLiveShare');
+  await GpsTrack.stopLiveShare();
+}
+
+export async function nativeUpdateLiveShareSettings(opts: {
+  intervalMs: number;
+  distanceM: number;
+}): Promise<void> {
+  console.log('[GpsTrack/native] updateLiveShareSettings', opts);
+  await GpsTrack.updateLiveShareSettings(opts);
+}
+```
+
+Plugin-Typ in `radiacodeNotification.ts` muss um diese Methoden erweitert werden — checke die Datei und ergänze die `definePlugin`-Signatur.
+
+**Verification:** `npx tsc --noEmit src/hooks/recording/nativeGpsTrackBridge.ts` erzeugt keinen Fehler. Web läuft auch ohne Native (`isNativeGpsTrackingAvailable()` schützt die Aufrufe).
+
+---
+
+## Task 9: Native Android — Foreground Service erweitern
+
+**Files (Anhaltspunkte; konkrete Datei-Aufteilung beim Implementieren festlegen):**
+- Modify: `capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeNotificationPlugin.java` — neue `@PluginMethod`-Funktionen: `startLiveShare`, `stopLiveShare`, `updateLiveShareSettings`.
+- Modify: `capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt` — separate Modus-Flags `trackActive`, `liveShareActive`. Service stoppt nur, wenn beide off. Notification-Text wird kontextabhängig zusammengesetzt (siehe Design).
+- Create: `capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/livelocation/LiveLocationPusher.kt` — eigener GPS-Listener + Throttle-Gate (analog `gpstrack/SampleGate.kt`), schreibt `livelocation`-Doc via Firestore Admin SDK (oder REST mit ID-Token, je nach existierendem Pattern in `gpstrack/FirestoreLineUpdater.kt` — nachschauen und konsistent halten).
+- Reuse: `gpstrack/Haversine`-Helper für Distanz (oder neu in einem Util).
+
+**Wichtige Details:**
+
+- TTL-Feld `expiresAt` muss als Firestore `Timestamp` geschrieben werden, korrekt mit `Date.now() + 60 min` befüllt.
+- Bei `stopLiveShare`: das eigene Doc löschen.
+- Bei `updateLiveShareSettings`: Throttle-Gate-Werte zur Laufzeit anpassen.
+- `firecallName` für die Notification durchreichen.
+- AndroidManifest: prüfen, ob `ACCESS_BACKGROUND_LOCATION` und `FOREGROUND_SERVICE_LOCATION` schon deklariert sind; falls nicht, hinzufügen.
+
+**Build-Check:**
+```bash
+cd capacitor/android
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :app:assembleDebug
+```
+
+**Verification:** Android-Build kompiliert. Manuelle Verifikation in Task 11.
+
+---
+
+## Task 10: Lifecycle / Edge-Cases
+
+**Files:**
+- Refine: `src/components/providers/LiveLocationProvider.tsx`
+
+Folgende Aspekte explizit prüfen und ggf. nachbessern:
+
+1. **Permission revoked während Sharing aktiv**: `usePosition` setzt `isSet` zurück bei dauerhaften Fehlern; im Provider beobachten und Sharing automatisch stoppen mit Snackbar-Hinweis.
+2. **`beforeunload` ist nicht zuverlässig**: zusätzlich `visibilitychange` → `document.hidden` honorieren (auf Mobile-Browsern stabiler). Best-Effort, kein harter Garantie-Anspruch.
+3. **Mehrere Tabs gleichzeitig**: kein zusätzlicher Schutz nötig — letzter Schreibender gewinnt; `deleteOwn` beim Schließen eines Tabs löscht aber das Doc, was den anderen Tab kurz „leer" macht. Dokumentieren in der PR-Beschreibung als bekannte Eigenschaft.
+4. **Native-Aktiv + Browser-Tab geschlossen**: Native Foreground Service läuft weiter; das ist gewünscht. `LiveLocationProvider` darf in dem Fall **nicht** automatisch löschen (mehrdeutig, weil Native gerade schreibt). → Lösung: beim Native-Mode den `deleteOwn`-Cleanup in `useEffect`-Cleanup unterdrücken, indem ein Flag im Hook geprüft wird.
+
+**Verification:** Code-Review der Lifecycle-Logik im Provider; ggf. zusätzlicher Test im Provider-Spec.
+
+---
+
+## Task 11: Final Checks, Manuelle Verifikation, Commit & PR
+
+**Step 1: Volle Checks (einzeln, nicht `npm run check`):**
+
+```bash
+git checkout -- next-env.d.ts || true
+npx tsc --noEmit
+npx eslint
+npx vitest run
+npx next build --webpack
+```
+
+Alle müssen grün sein. **Keine Commit, solange tsc Fehler meldet** — auch keine vermeintlich pre-existing.
+
+**Step 2: Manuelle Verifikation Browser:**
+
+- Dev-Server starten (`npm run dev`).
+- Mit zwei Browser-Profilen / -Geräten gleichzeitig in denselben Firecall einloggen.
+- User A startet Live-Sharing → User B sieht Avatar + Label.
+- User A bewegt sich (oder simuliert via DevTools-Geolocation) → Position aktualisiert sich bei B.
+- User A stoppt → Marker verschwindet bei B.
+- Test: Firecall-Wechsel bei aktivem Sharing → Sharing stoppt + Doc gelöscht.
+- Test: Tab schließen → Marker verschwindet bei B (best-effort).
+- Test: Permission verweigert → FAB nicht aktivierbar bzw. Fehler-Hinweis.
+- Test: nach 5 min ohne Update → Marker fade von 2 min an, weg ab 5 min.
+- Test: Doppel-Marker eigener User darf **nicht** auftauchen (eigene UID gefiltert).
+
+**Step 3: Manuelle Verifikation Native (Android, falls Build durchläuft):**
+
+- APK auf Testgerät installieren.
+- Live-Sharing starten → Notification mit Einsatz-Name erscheint.
+- App in den Hintergrund → Standort wird weiter geteilt (im Browser oder zweiten Gerät prüfen).
+- Track-Recording parallel starten → Notification-Text zeigt beides.
+- Stoppen via FAB / via Notification-Action (falls vorgesehen) → beide Modi sauber beendet.
+- Reboot-Verhalten: Sharing nach Reboot nicht automatisch wieder aktiv.
+
+**Step 4: Commit + Push + PR**
+
+```bash
+git add ...   # alle relevanten Dateien explizit
+git commit -m "feat(map): live location sharing per firecall"
+git push -u origin feature/live-location
+```
+
+PR-Beschreibung auf Deutsch, Titel als Conventional Commit, Test plan ausfüllen — siehe CLAUDE.md Pull-Request-Sektion.
+
+**PR-Beschreibung-Vorlage:**
+
+```markdown
+## Zusammenfassung
+
+Einsatzkräfte können ihren Live-Standort innerhalb eines aktiven Firecalls für andere Berechtigte sichtbar machen. Andere User sehen die Standorte als Avatar-Marker mit Namens-Label auf der Einsatzkarte. Native Android unterstützt Background-Sharing via Foreground Service, integriert in den bestehenden GPS-Track-Service.
+
+## Änderungen
+
+- Neue Firestore-Subcollection `call/{firecallId}/livelocation/{uid}` mit TTL Policy
+- Schreib-Hook mit OR-Throttling (Default 30 s ODER 20 m, anpassbar)
+- Eigene Leaflet-Layer „Live-Standorte" mit Avatar-Markern (Initialen + Namens-Label)
+- FAB über dem Aufnahme-Button, Bestätigungs-Dialog mit erweiterten Einstellungen
+- Settings persistiert in localStorage
+- Soft-Fade ab 2 min, hart-Cutoff bei 5 min
+- Auto-Stopp bei Firecall-Wechsel oder Page-Unmount
+- Native Android: Foreground Service erweitert um unabhängigen `liveShare`-Modus
+- Security Rules: Schreibzugriff auf eigene UID begrenzt, Read für alle Firecall-User
+
+## Test plan
+
+- [ ] Zwei Geräte/Browser im selben Firecall: A teilt → B sieht Marker
+- [ ] Bewegung von A spiegelt sich bei B nach Distanz-/Heartbeat-Bedingung
+- [ ] Stop bei A → Marker bei B verschwindet
+- [ ] Firecall-Wechsel: Sharing stoppt, altes Doc gelöscht
+- [ ] Permission verweigert: FAB-Fehler-Zustand
+- [ ] Marker faded nach 2 min, verschwindet nach 5 min
+- [ ] Eigener Marker nicht doppelt sichtbar
+- [ ] Android: Foreground-Service-Notification mit Einsatz-Name
+- [ ] Android: Sharing läuft im Hintergrund weiter
+- [ ] Android: Track-Recording + Live-Share parallel funktionieren
+- [ ] TTL Policy nach Deploy aktiviert (manuell, dev + prod)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+**Step 5: Hinweis im PR-Text** auf den manuellen Deployment-Schritt für die Firestore TTL Policy.
+
+---
+
+## Build-Sequenz Zusammenfassung
+
+| # | Task | Abhängigkeiten |
+|---|---|---|
+| 1 | Datenmodell + Helper | — |
+| 2 | Security Rules + TTL | 1 |
+| 3 | Settings-Hook | — |
+| 4 | Schreib-Hook | 1, 3 |
+| 5 | Provider | 4 |
+| 6 | Read-Hook + Layer + Marker | 1 |
+| 7 | FAB + Dialog | 5 |
+| 8 | Native Bridge TS | 5 |
+| 9 | Native Android Service | 8 |
+| 10 | Lifecycle-Refine | 5, 7 |
+| 11 | Checks + Manual + PR | alle |
+
+Tasks 1, 3, 6 (in Teilen) und 8 sind unabhängig und könnten parallelisiert werden, falls Subagents zur Verfügung stehen.

--- a/firebase/dev/firestore.rules
+++ b/firebase/dev/firestore.rules
@@ -64,6 +64,20 @@ service cloud.firestore {
         // No update or delete allowed for audit log entries
       }
 
+      // Live location sharing: read for any firecall-authorized user,
+      // write/delete only for the doc owner whose UID equals the doc id.
+      match /livelocation/{userId} {
+        allow read: if callAuthorized();
+        allow create: if callAuthorized()
+          && userId == request.auth.uid
+          && request.resource.data.uid == request.auth.uid;
+        allow update: if callAuthorized()
+          && userId == request.auth.uid
+          && request.resource.data.uid == request.auth.uid;
+        allow delete: if callAuthorized()
+          && userId == request.auth.uid;
+      }
+
       match /{subitem=**} {
         allow read, write: if callAuthorized()
       }

--- a/firebase/dev/firestore.rules
+++ b/firebase/dev/firestore.rules
@@ -129,9 +129,11 @@ service cloud.firestore {
       allow write: if adminUser();
     }
 
-    // Kostenersatz vehicles - read for kostenersatz group, write for admin
+    // Kostenersatz vehicles - read for any authorized user (the vehicle
+    // list powers einsatz-side autocomplete via EinsatzortEditDialog and
+    // is needed by every FF member), write for admin.
     match /kostenersatzVehicles/{doc=**} {
-      allow read: if kostenersatzUser();
+      allow read: if authorizedUser();
       allow write: if adminUser();
     }
 

--- a/firebase/prod/firestore.rules
+++ b/firebase/prod/firestore.rules
@@ -64,6 +64,20 @@ service cloud.firestore {
         // No update or delete allowed for audit log entries
       }
 
+      // Live location sharing: read for any firecall-authorized user,
+      // write/delete only for the doc owner whose UID equals the doc id.
+      match /livelocation/{userId} {
+        allow read: if callAuthorized();
+        allow create: if callAuthorized()
+          && userId == request.auth.uid
+          && request.resource.data.uid == request.auth.uid;
+        allow update: if callAuthorized()
+          && userId == request.auth.uid
+          && request.resource.data.uid == request.auth.uid;
+        allow delete: if callAuthorized()
+          && userId == request.auth.uid;
+      }
+
       match /{subitem=**} {
         allow read, write: if callAuthorized()
       }

--- a/firebase/prod/firestore.rules
+++ b/firebase/prod/firestore.rules
@@ -129,9 +129,11 @@ service cloud.firestore {
       allow write: if adminUser();
     }
 
-    // Kostenersatz vehicles - read for kostenersatz group, write for admin
+    // Kostenersatz vehicles - read for any authorized user (the vehicle
+    // list powers einsatz-side autocomplete via EinsatzortEditDialog and
+    // is needed by every FF member), write for admin.
     match /kostenersatzVehicles/{doc=**} {
-      allow read: if kostenersatzUser();
+      allow read: if authorizedUser();
       allow write: if adminUser();
     }
 

--- a/src/common/liveLocation.test.ts
+++ b/src/common/liveLocation.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeInitials,
+  pickAvatarColor,
+  isFresh,
+  computeOpacity,
+  LIVE_LOCATION_COLLECTION_ID,
+  STALE_HARD_CUTOFF_MS,
+  STALE_FADE_START_MS,
+} from './liveLocation';
+
+describe('liveLocation helpers', () => {
+  describe('computeInitials', () => {
+    it('takes first letter of first two words', () => {
+      expect(computeInitials('Paul Wölfel', 'paul@x.at')).toBe('PW');
+    });
+    it('falls back to single first letter for one-word names', () => {
+      expect(computeInitials('Paul', 'paul@x.at')).toBe('P');
+    });
+    it('uses first 2 chars of email local part when name is empty', () => {
+      expect(computeInitials('', 'paul.woelfel@example.com')).toBe('PA');
+    });
+    it('returns ?? when neither name nor email usable', () => {
+      expect(computeInitials('', '')).toBe('??');
+    });
+    it('handles emoji and other supplementary-plane chars without breaking', () => {
+      expect(computeInitials('🚒 Truck', '')).toBe('🚒T');
+      // No half-surrogate in result — length in codepoints should equal 2 chars expressed as 2 codepoints.
+      expect(Array.from(computeInitials('🚒 Engine', ''))).toEqual(['🚒', 'E']);
+      // Email fallback path: first 2 codepoints, not 2 code units.
+      expect(Array.from(computeInitials('', '🚒🔥@x.at'))).toEqual(['🚒', '🔥']);
+    });
+  });
+
+  describe('pickAvatarColor', () => {
+    it('is deterministic for same uid', () => {
+      expect(pickAvatarColor('uid-1')).toBe(pickAvatarColor('uid-1'));
+    });
+    it('returns a valid hex color', () => {
+      expect(pickAvatarColor('uid-1')).toMatch(/^#[0-9a-f]{6}$/i);
+    });
+    it('returns one of the palette colors', () => {
+      const c = pickAvatarColor('any-uid');
+      expect(typeof c).toBe('string');
+      expect(c.length).toBe(7);
+    });
+  });
+
+  describe('isFresh / computeOpacity', () => {
+    const now = 1_700_000_000_000;
+    it('returns true when within hard cutoff', () => {
+      expect(isFresh(now - 4 * 60_000, now)).toBe(true);
+    });
+    it('returns false past hard cutoff', () => {
+      expect(isFresh(now - 6 * 60_000, now)).toBe(false);
+    });
+    it('opacity is 1 below fade start', () => {
+      expect(computeOpacity(now - 1 * 60_000, now)).toBe(1);
+    });
+    it('opacity is 0 past hard cutoff', () => {
+      expect(computeOpacity(now - 6 * 60_000, now)).toBe(0);
+    });
+    it('opacity scales linearly between fade start and cutoff', () => {
+      const mid = now - ((STALE_FADE_START_MS + STALE_HARD_CUTOFF_MS) / 2);
+      const v = computeOpacity(mid, now);
+      expect(v).toBeGreaterThan(0.3);
+      expect(v).toBeLessThan(1);
+    });
+  });
+
+  it('exposes the collection id constant', () => {
+    expect(LIVE_LOCATION_COLLECTION_ID).toBe('livelocation');
+  });
+});

--- a/src/common/liveLocation.ts
+++ b/src/common/liveLocation.ts
@@ -1,0 +1,91 @@
+import { Timestamp } from 'firebase/firestore';
+
+export const LIVE_LOCATION_COLLECTION_ID = 'livelocation';
+
+export const STALE_FADE_START_MS = 2 * 60 * 1000; // 2 min
+export const STALE_HARD_CUTOFF_MS = 5 * 60 * 1000; // 5 min
+export const TTL_EXPIRY_MS = 60 * 60 * 1000; // 1 h (Firestore TTL)
+
+export interface LiveLocation {
+  uid: string;
+  name: string;
+  email: string;
+  lat: number;
+  lng: number;
+  accuracy?: number;
+  heading?: number;
+  speed?: number;
+  updatedAt: Timestamp;
+  expiresAt: Timestamp;
+}
+
+const PALETTE = [
+  '#1976d2',
+  '#388e3c',
+  '#d32f2f',
+  '#f57c00',
+  '#7b1fa2',
+  '#0288d1',
+  '#c2185b',
+  '#5d4037',
+  '#00796b',
+  '#fbc02d',
+  '#512da8',
+  '#455a64',
+];
+
+export function pickAvatarColor(uid: string): string {
+  let hash = 0;
+  for (let i = 0; i < uid.length; i++) {
+    hash = (hash * 31 + uid.charCodeAt(i)) | 0;
+  }
+  const idx = Math.abs(hash) % PALETTE.length;
+  return PALETTE[idx];
+}
+
+const firstCodePoint = (s: string): string => {
+  for (const ch of s) return ch;
+  return '';
+};
+
+const firstCodePoints = (s: string, n: number): string => {
+  const out: string[] = [];
+  for (const ch of s) {
+    out.push(ch);
+    if (out.length >= n) break;
+  }
+  return out.join('');
+};
+
+export function computeInitials(name: string, email: string): string {
+  const trimmed = name.trim();
+  if (trimmed) {
+    const parts = trimmed.split(/\s+/).filter(Boolean);
+    if (parts.length >= 2) {
+      return (firstCodePoint(parts[0]) + firstCodePoint(parts[1])).toUpperCase();
+    }
+    const first = firstCodePoint(parts[0]);
+    return first ? first.toUpperCase() : '?';
+  }
+  const local = (email.split('@')[0] || '').trim();
+  if (local) {
+    return firstCodePoints(local, 2).toUpperCase();
+  }
+  return '??';
+}
+
+export function isFresh(updatedAtMs: number, nowMs: number = Date.now()): boolean {
+  return nowMs - updatedAtMs < STALE_HARD_CUTOFF_MS;
+}
+
+export function computeOpacity(
+  updatedAtMs: number,
+  nowMs: number = Date.now()
+): number {
+  const age = nowMs - updatedAtMs;
+  if (age <= STALE_FADE_START_MS) return 1;
+  if (age >= STALE_HARD_CUTOFF_MS) return 0;
+  const fadeRange = STALE_HARD_CUTOFF_MS - STALE_FADE_START_MS;
+  const fadeProgress = (age - STALE_FADE_START_MS) / fadeRange;
+  return 1 - fadeProgress * 0.7; // 1.0 → 0.3 over fade range
+}

--- a/src/components/LiveLocation/LiveLocationDialog.test.tsx
+++ b/src/components/LiveLocation/LiveLocationDialog.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import LiveLocationDialog from './LiveLocationDialog';
+import {
+  DEFAULT_DISTANCE_M,
+  DEFAULT_HEARTBEAT_MS,
+  LiveLocationSettings,
+} from '../../hooks/useLiveLocationSettings';
+
+const defaultSettings: LiveLocationSettings = {
+  heartbeatMs: DEFAULT_HEARTBEAT_MS,
+  distanceM: DEFAULT_DISTANCE_M,
+};
+
+describe('LiveLocationDialog', () => {
+  it('renders title and body with firecall name', () => {
+    render(
+      <LiveLocationDialog
+        open
+        onClose={vi.fn()}
+        firecallName="Kellerbrand Hauptstraße"
+        settings={defaultSettings}
+        setSettings={vi.fn()}
+        onStart={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Standort teilen?')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Kellerbrand Hauptstraße/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows current heartbeat and distance values from settings', () => {
+    render(
+      <LiveLocationDialog
+        open
+        onClose={vi.fn()}
+        firecallName="Test"
+        settings={{ heartbeatMs: 45_000, distanceM: 25 }}
+        setSettings={vi.fn()}
+        onStart={vi.fn()}
+      />,
+    );
+    // Expand advanced settings accordion to make sliders visible.
+    fireEvent.click(screen.getByText('Erweiterte Einstellungen'));
+    const heartbeatSlider = screen.getByLabelText(/Heartbeat/);
+    const distanceSlider = screen.getByLabelText(/Distanz/);
+    expect(heartbeatSlider).toHaveAttribute('value', '45000');
+    expect(distanceSlider).toHaveAttribute('value', '25');
+  });
+
+  it('calls setSettings (if changed) and onStart when "Standort teilen" is clicked', () => {
+    const setSettings = vi.fn();
+    const onStart = vi.fn();
+    render(
+      <LiveLocationDialog
+        open
+        onClose={vi.fn()}
+        firecallName="Test"
+        settings={defaultSettings}
+        setSettings={setSettings}
+        onStart={onStart}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Standort teilen' }));
+    expect(onStart).toHaveBeenCalledTimes(1);
+    // Default values were used → no change → setSettings should not be called.
+    expect(setSettings).not.toHaveBeenCalled();
+  });
+
+  it('calls setSettings with new values when slider changed before submit', () => {
+    const setSettings = vi.fn();
+    const onStart = vi.fn();
+    render(
+      <LiveLocationDialog
+        open
+        onClose={vi.fn()}
+        firecallName="Test"
+        settings={defaultSettings}
+        setSettings={setSettings}
+        onStart={onStart}
+      />,
+    );
+    fireEvent.click(screen.getByText('Erweiterte Einstellungen'));
+    const heartbeatSlider = screen.getByLabelText(/Heartbeat/);
+    fireEvent.change(heartbeatSlider, { target: { value: '60000' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Standort teilen' }));
+    expect(setSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ heartbeatMs: 60_000 }),
+    );
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when "Abbrechen" is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <LiveLocationDialog
+        open
+        onClose={onClose}
+        firecallName="Test"
+        settings={defaultSettings}
+        setSettings={vi.fn()}
+        onStart={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/LiveLocation/LiveLocationDialog.tsx
+++ b/src/components/LiveLocation/LiveLocationDialog.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Slider from '@mui/material/Slider';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import {
+  DISTANCE_MAX_M,
+  DISTANCE_MIN_M,
+  HEARTBEAT_MAX_MS,
+  HEARTBEAT_MIN_MS,
+  LiveLocationSettings,
+} from '../../hooks/useLiveLocationSettings';
+
+export interface LiveLocationDialogProps {
+  open: boolean;
+  onClose: () => void;
+  firecallName: string;
+  settings: LiveLocationSettings;
+  setSettings: (next: LiveLocationSettings) => void;
+  onStart: () => void;
+}
+
+function LiveLocationDialogBody({
+  onClose,
+  firecallName,
+  settings,
+  setSettings,
+  onStart,
+}: Omit<LiveLocationDialogProps, 'open'>) {
+  const [heartbeatMs, setHeartbeatMs] = useState(settings.heartbeatMs);
+  const [distanceM, setDistanceM] = useState(settings.distanceM);
+
+  const handleSubmit = () => {
+    if (
+      heartbeatMs !== settings.heartbeatMs ||
+      distanceM !== settings.distanceM
+    ) {
+      setSettings({ heartbeatMs, distanceM });
+    }
+    onStart();
+  };
+
+  return (
+    <>
+      <DialogTitle>Standort teilen?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {`Dein Live-Standort wird für andere Einsatzkräfte im Einsatz „${
+            firecallName || 'aktueller Einsatz'
+          }" sichtbar.`}
+        </DialogContentText>
+
+        <Accordion sx={{ mt: 2 }} disableGutters elevation={0}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography>Erweiterte Einstellungen</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Box sx={{ px: 1 }}>
+              <Typography
+                id="live-loc-heartbeat-label"
+                gutterBottom
+                variant="body2"
+              >
+                Heartbeat: {Math.round(heartbeatMs / 1000)} s
+              </Typography>
+              <Slider
+                aria-label="Heartbeat"
+                aria-labelledby="live-loc-heartbeat-label"
+                value={heartbeatMs}
+                min={HEARTBEAT_MIN_MS}
+                max={HEARTBEAT_MAX_MS}
+                step={5_000}
+                valueLabelDisplay="auto"
+                valueLabelFormat={(v: number) =>
+                  `${Math.round(v / 1000)} s`
+                }
+                onChange={(_, v) =>
+                  setHeartbeatMs(Array.isArray(v) ? v[0] : v)
+                }
+              />
+              <Typography
+                id="live-loc-distance-label"
+                gutterBottom
+                variant="body2"
+                sx={{ mt: 2 }}
+              >
+                Distanz: {distanceM} m
+              </Typography>
+              <Slider
+                aria-label="Distanz"
+                aria-labelledby="live-loc-distance-label"
+                value={distanceM}
+                min={DISTANCE_MIN_M}
+                max={DISTANCE_MAX_M}
+                step={5}
+                valueLabelDisplay="auto"
+                valueLabelFormat={(v: number) => `${v} m`}
+                onChange={(_, v) =>
+                  setDistanceM(Array.isArray(v) ? v[0] : v)
+                }
+              />
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Abbrechen</Button>
+        <Button onClick={handleSubmit} variant="contained">
+          Standort teilen
+        </Button>
+      </DialogActions>
+    </>
+  );
+}
+
+export default function LiveLocationDialog(props: LiveLocationDialogProps) {
+  const { open, onClose } = props;
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      // Remount the body each time the dialog opens so local slider state
+      // is re-initialized from the latest settings prop.
+      key={open ? 'open' : 'closed'}
+    >
+      {open ? <LiveLocationDialogBody {...props} /> : null}
+    </Dialog>
+  );
+}

--- a/src/components/LiveLocation/LiveLocationFab.tsx
+++ b/src/components/LiveLocation/LiveLocationFab.tsx
@@ -76,7 +76,7 @@ export default function LiveLocationFab() {
       <Box
         sx={{
           position: 'absolute',
-          bottom: 120,
+          bottom: 112,
           left: 16,
         }}
       >

--- a/src/components/LiveLocation/LiveLocationFab.tsx
+++ b/src/components/LiveLocation/LiveLocationFab.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
+import Box from '@mui/material/Box';
+import Fab from '@mui/material/Fab';
+import Tooltip from '@mui/material/Tooltip';
+import { useState } from 'react';
+import { useFirecall } from '../../hooks/useFirecall';
+import { useLiveLocationContext } from '../providers/LiveLocationProvider';
+import LiveLocationDialog from './LiveLocationDialog';
+import LiveLocationStopConfirm from './LiveLocationStopConfirm';
+
+export default function LiveLocationFab() {
+  const { isSharing, settings, setSettings, start, stop, canShare } =
+    useLiveLocationContext();
+  const firecall = useFirecall();
+  const [startOpen, setStartOpen] = useState(false);
+  const [stopOpen, setStopOpen] = useState(false);
+
+  if (!canShare) return null;
+
+  const handleClick = () => {
+    if (isSharing) {
+      setStopOpen(true);
+    } else {
+      setStartOpen(true);
+    }
+  };
+
+  const handleStart = () => {
+    setStartOpen(false);
+    void start();
+  };
+
+  const handleStop = () => {
+    void stop();
+  };
+
+  return (
+    <>
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: 184,
+          left: 16,
+        }}
+      >
+        <Tooltip
+          title={isSharing ? 'Live-Sharing läuft' : 'Live-Standort teilen'}
+        >
+          <Fab
+            color={isSharing ? 'primary' : 'default'}
+            aria-label={
+              isSharing ? 'Live-Sharing beenden' : 'Live-Standort teilen'
+            }
+            size="small"
+            onClick={handleClick}
+            sx={{
+              animation: isSharing
+                ? 'liveLocPulse 2s ease-in-out infinite'
+                : 'none',
+              '@keyframes liveLocPulse': {
+                '0%, 100%': {
+                  boxShadow: '0 0 0 0 rgba(25, 118, 210, .55)',
+                },
+                '50%': {
+                  boxShadow: '0 0 0 8px rgba(25, 118, 210, 0)',
+                },
+              },
+            }}
+          >
+            {isSharing ? <LocationOnIcon /> : <LocationOnOutlinedIcon />}
+          </Fab>
+        </Tooltip>
+      </Box>
+      <LiveLocationDialog
+        open={startOpen}
+        onClose={() => setStartOpen(false)}
+        firecallName={firecall.name}
+        settings={settings}
+        setSettings={setSettings}
+        onStart={handleStart}
+      />
+      <LiveLocationStopConfirm
+        open={stopOpen}
+        onClose={() => setStopOpen(false)}
+        onConfirm={handleStop}
+      />
+    </>
+  );
+}

--- a/src/components/LiveLocation/LiveLocationFab.tsx
+++ b/src/components/LiveLocation/LiveLocationFab.tsx
@@ -5,27 +5,55 @@ import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
 import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFirecall } from '../../hooks/useFirecall';
 import { useLiveLocationContext } from '../providers/LiveLocationProvider';
+import { usePositionContext } from '../providers/PositionProvider';
 import LiveLocationDialog from './LiveLocationDialog';
 import LiveLocationStopConfirm from './LiveLocationStopConfirm';
 
 export default function LiveLocationFab() {
-  const { isSharing, settings, setSettings, start, stop, canShare } =
+  const { isSharing, settings, setSettings, start, stop } =
     useLiveLocationContext();
+  const [, isPositionSet, , enableTracking, isPositionPending] =
+    usePositionContext();
   const firecall = useFirecall();
   const [startOpen, setStartOpen] = useState(false);
   const [stopOpen, setStopOpen] = useState(false);
+  const [pendingDialogOpen, setPendingDialogOpen] = useState(false);
 
-  if (!canShare) return null;
+  // Once the position arrives after a click, open the start dialog. If the
+  // request fails (permission denied / unavailable) clear the pending flag.
+  // Deferring via setTimeout keeps these reactive setState calls out of the
+  // effect body proper (avoids react-hooks/set-state-in-effect).
+  useEffect(() => {
+    if (!pendingDialogOpen) return;
+    if (isPositionSet) {
+      const t = setTimeout(() => {
+        setPendingDialogOpen(false);
+        setStartOpen(true);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    if (!isPositionPending) {
+      const t = setTimeout(() => {
+        setPendingDialogOpen(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+  }, [pendingDialogOpen, isPositionSet, isPositionPending]);
 
   const handleClick = () => {
     if (isSharing) {
       setStopOpen(true);
-    } else {
-      setStartOpen(true);
+      return;
     }
+    if (!isPositionSet) {
+      enableTracking();
+      setPendingDialogOpen(true);
+      return;
+    }
+    setStartOpen(true);
   };
 
   const handleStart = () => {
@@ -37,18 +65,22 @@ export default function LiveLocationFab() {
     void stop();
   };
 
+  const tooltipTitle = isSharing
+    ? 'Live-Sharing läuft'
+    : isPositionPending || pendingDialogOpen
+      ? 'Position wird ermittelt …'
+      : 'Live-Standort teilen';
+
   return (
     <>
       <Box
         sx={{
           position: 'absolute',
-          bottom: 184,
+          bottom: 120,
           left: 16,
         }}
       >
-        <Tooltip
-          title={isSharing ? 'Live-Sharing läuft' : 'Live-Standort teilen'}
-        >
+        <Tooltip title={tooltipTitle}>
           <Fab
             color={isSharing ? 'primary' : 'default'}
             aria-label={

--- a/src/components/LiveLocation/LiveLocationStopConfirm.tsx
+++ b/src/components/LiveLocation/LiveLocationStopConfirm.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+export interface LiveLocationStopConfirmProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function LiveLocationStopConfirm({
+  open,
+  onClose,
+  onConfirm,
+}: LiveLocationStopConfirmProps) {
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Live-Sharing beenden?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Dein Live-Standort wird nicht mehr mit anderen Einsatzkräften geteilt.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Abbrechen</Button>
+        <Button onClick={handleConfirm} color="error" variant="contained">
+          Beenden
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -28,6 +28,7 @@ import FitBoundsToItems from './FitBoundsToItems';
 import UpdateMapPosition from './UpdateMapPosition';
 import { DistanceLayer } from './layers/DistanceLayer';
 import FirecallLayer from './layers/FirecallLayer';
+import LiveLocationLayer from './layers/LiveLocationLayer';
 import LocationsLayer from './layers/LocationsLayer';
 import DistanceMarker from './markers/DistanceMarker';
 import PowerOutageLayer from './layers/PowerOutageLayer';
@@ -128,6 +129,9 @@ export default function Map() {
           </LayersControl.Overlay>
           <LayersControl.Overlay name="Position" checked>
             <PositionMarker />
+          </LayersControl.Overlay>
+          <LayersControl.Overlay name="Live-Standorte" checked>
+            <LiveLocationLayer />
           </LayersControl.Overlay>
           <LayersControl.Overlay name="Stromausfälle">
             <PowerOutageLayer />

--- a/src/components/Map/MapActionButtons.tsx
+++ b/src/components/Map/MapActionButtons.tsx
@@ -3,33 +3,18 @@
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import HistoryIcon from '@mui/icons-material/History';
-import SaveIcon from '@mui/icons-material/Save';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import Box from '@mui/material/Box';
-import CircularProgress from '@mui/material/CircularProgress';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
 import L from 'leaflet';
-import React, { useCallback, useState } from 'react';
-import { useMap, useMapEvent } from 'react-leaflet';
-import useFirecallItemAdd from '../../hooks/useFirecallItemAdd';
 import useMapEditor from '../../hooks/useMapEditor';
-import FirecallItemDialog from '../FirecallItems/FirecallItemDialog';
-import { fcItemClasses, getItemInstance } from '../FirecallItems/elements';
-import {
-  Connection,
-  FirecallItem,
-  NON_DISPLAYABLE_ITEMS,
-} from '../firebase/firestore';
-import { useLeitungen } from './Leitungen/context';
-import RecordButton from './RecordButton';
-import SearchButton from './SearchButton';
 import LiveLocationFab from '../LiveLocation/LiveLocationFab';
-import InputDialog from '../dialogs/InputDialog';
-import { formatTimestamp } from '../../common/time-format';
+import { useFirecallItems } from '../firebase/firestoreHooks';
 import AddFirecallItem from './AddFirecallItem';
 import AiAssistantButton from './AiAssistantButton';
-import { useFirecallItems } from '../firebase/firestoreHooks';
+import RecordButton from './RecordButton';
+import SearchButton from './SearchButton';
 
 export interface MapActionButtonsOptions {
   map: L.Map;

--- a/src/components/Map/MapActionButtons.tsx
+++ b/src/components/Map/MapActionButtons.tsx
@@ -24,6 +24,7 @@ import {
 import { useLeitungen } from './Leitungen/context';
 import RecordButton from './RecordButton';
 import SearchButton from './SearchButton';
+import LiveLocationFab from '../LiveLocation/LiveLocationFab';
 import InputDialog from '../dialogs/InputDialog';
 import { formatTimestamp } from '../../common/time-format';
 import AddFirecallItem from './AddFirecallItem';
@@ -45,6 +46,7 @@ export default function MapActionButtons({ map }: MapActionButtonsOptions) {
   const firecallItems = useFirecallItems();
   return (
     <>
+      <LiveLocationFab />
       <Box
         sx={{
           // '& > :not(style)': { m: 1 },

--- a/src/components/Map/PositionedMap.tsx
+++ b/src/components/Map/PositionedMap.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import Map from './Map';
-import { PositionProvider } from '../providers/PositionProvider';
 
 export default function PositionedMap() {
-  return (
-    <PositionProvider>
-      <Map />
-    </PositionProvider>
-  );
+  return <Map />;
 }

--- a/src/components/Map/RecordButton.tsx
+++ b/src/components/Map/RecordButton.tsx
@@ -13,7 +13,6 @@ import useFirebaseLogin from '../../hooks/useFirebaseLogin';
 import { useFirecallId } from '../../hooks/useFirecall';
 import { useFirecallLayersSorted } from '../../hooks/useFirecallLayers';
 import useFirecallItemAdd from '../../hooks/useFirecallItemAdd';
-import LiveLocationFab from '../LiveLocation/LiveLocationFab';
 import { useRadiacode } from '../providers/RadiacodeProvider';
 import { useGpsProvider } from '../providers/GpsProvider';
 import { usePositionContext } from '../providers/PositionProvider';
@@ -133,7 +132,6 @@ export default function RecordButton() {
 
   return (
     <>
-      <LiveLocationFab />
       <Box
         sx={{
           position: 'absolute',

--- a/src/components/Map/RecordButton.tsx
+++ b/src/components/Map/RecordButton.tsx
@@ -13,6 +13,7 @@ import useFirebaseLogin from '../../hooks/useFirebaseLogin';
 import { useFirecallId } from '../../hooks/useFirecall';
 import { useFirecallLayersSorted } from '../../hooks/useFirecallLayers';
 import useFirecallItemAdd from '../../hooks/useFirecallItemAdd';
+import LiveLocationFab from '../LiveLocation/LiveLocationFab';
 import { useRadiacode } from '../providers/RadiacodeProvider';
 import { useGpsProvider } from '../providers/GpsProvider';
 import { usePositionContext } from '../providers/PositionProvider';
@@ -132,6 +133,7 @@ export default function RecordButton() {
 
   return (
     <>
+      <LiveLocationFab />
       <Box
         sx={{
           position: 'absolute',

--- a/src/components/Map/RecordButton.tsx
+++ b/src/components/Map/RecordButton.tsx
@@ -2,20 +2,16 @@ import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
 import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import L from 'leaflet';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useGpsLineRecorder } from '../../hooks/recording/useGpsLineRecorder';
-import { useRadiacodePointRecorder } from '../../hooks/recording/useRadiacodePointRecorder';
 import { loadDefaultDevice } from '../../hooks/radiacode/devicePreference';
 import { createRadiacodeLayer } from '../../hooks/radiacode/layerFactory';
-import { RadiacodeDeviceRef, SampleRateSpec } from '../../hooks/radiacode/types';
-import useFirebaseLogin from '../../hooks/useFirebaseLogin';
+import { RadiacodeDeviceRef } from '../../hooks/radiacode/types';
 import { useFirecallId } from '../../hooks/useFirecall';
-import { useFirecallLayersSorted } from '../../hooks/useFirecallLayers';
 import useFirecallItemAdd from '../../hooks/useFirecallItemAdd';
-import { useRadiacode } from '../providers/RadiacodeProvider';
+import { useFirecallLayersSorted } from '../../hooks/useFirecallLayers';
 import { useGpsProvider } from '../providers/GpsProvider';
 import { usePositionContext } from '../providers/PositionProvider';
+import { useRadiacode } from '../providers/RadiacodeProvider';
 import RadiacodeLiveWidget from './RadiacodeLiveWidget';
 import TrackStartDialog, { TrackStartConfig } from './TrackStartDialog';
 
@@ -25,8 +21,6 @@ export default function RecordButton() {
   const {
     isRecording,
     mode,
-    layerId,
-    sampleRate,
     startGpsRecording,
     startRadiacodeRecording,
     stopRecording,
@@ -35,7 +29,6 @@ export default function RecordButton() {
   const sortedLayers = useFirecallLayersSorted();
   const addFirecallItem = useFirecallItemAdd();
   const firecallId = useFirecallId();
-  const { email: creatorEmail } = useFirebaseLogin();
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [pendingDialogOpen, setPendingDialogOpen] = useState(false);
@@ -62,11 +55,7 @@ export default function RecordButton() {
     }
   }, [isPositionSet, pendingDialogOpen, isPositionPending]);
 
-  const {
-    status: radiacodeStatus,
-    scan,
-    connectDevice,
-  } = useRadiacode();
+  const { status: radiacodeStatus, scan, connectDevice } = useRadiacode();
 
   const existingRadiacodeLayers = useMemo(
     () => sortedLayers.filter((l) => l.layerType === 'radiacode'),
@@ -84,7 +73,10 @@ export default function RecordButton() {
     async (config: TrackStartConfig) => {
       setDialogOpen(false);
       if (config.mode === 'gps') {
-        await startGpsRecording(config.layer?.type === 'existing' ? config.layer.id : '', config.sampleRate);
+        await startGpsRecording(
+          config.layer?.type === 'existing' ? config.layer.id : '',
+          config.sampleRate,
+        );
         return;
       }
       // radiacode mode
@@ -103,12 +95,21 @@ export default function RecordButton() {
 
       try {
         await connectDevice(config.device);
-        await startRadiacodeRecording(config.device, targetLayerId, config.sampleRate);
+        await startRadiacodeRecording(
+          config.device,
+          targetLayerId,
+          config.sampleRate,
+        );
       } catch (err) {
         console.error('[RADIACODE] connect failed', err);
       }
     },
-    [connectDevice, addFirecallItem, startGpsRecording, startRadiacodeRecording],
+    [
+      connectDevice,
+      addFirecallItem,
+      startGpsRecording,
+      startRadiacodeRecording,
+    ],
   );
 
   const handleStop = useCallback(() => {
@@ -135,7 +136,7 @@ export default function RecordButton() {
       <Box
         sx={{
           position: 'absolute',
-          bottom: 120,
+          bottom: 176,
           left: 16,
         }}
       >

--- a/src/components/Map/RecordButton.tsx
+++ b/src/components/Map/RecordButton.tsx
@@ -136,7 +136,7 @@ export default function RecordButton() {
       <Box
         sx={{
           position: 'absolute',
-          bottom: 176,
+          bottom: 160,
           left: 16,
         }}
       >

--- a/src/components/Map/layers/LiveLocationLayer.tsx
+++ b/src/components/Map/layers/LiveLocationLayer.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { LayerGroup } from 'react-leaflet';
+import { useLiveLocations } from '../../../hooks/useLiveLocations';
+import LiveLocationMarker from '../markers/LiveLocationMarker';
+
+export default function LiveLocationLayer() {
+  const locations = useLiveLocations();
+  return (
+    <LayerGroup>
+      {locations.map((loc) => (
+        <LiveLocationMarker key={loc.id} loc={loc} />
+      ))}
+    </LayerGroup>
+  );
+}

--- a/src/components/Map/markers/LiveLocationMarker.test.tsx
+++ b/src/components/Map/markers/LiveLocationMarker.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildIconHtml, formatRelative } from './LiveLocationMarker';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('formatRelative', () => {
+  it('formats seconds when under one minute', () => {
+    const now = 1_000_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    expect(formatRelative(now - 30_000)).toBe('vor 30 s');
+  });
+
+  it('formats minutes when one minute or more', () => {
+    const now = 1_000_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    expect(formatRelative(now - 3 * 60 * 1000)).toBe('vor 3 min');
+  });
+
+  it('clamps negative ages to 0 seconds', () => {
+    const now = 1_000_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    // future timestamp -> negative age
+    expect(formatRelative(now + 5_000)).toBe('vor 0 s');
+  });
+});
+
+describe('buildIconHtml', () => {
+  it('contains initials, color, and display name', () => {
+    const html = buildIconHtml({
+      initials: 'AB',
+      color: '#1976d2',
+      displayName: 'Anna Bauer',
+      opacity: 1,
+    });
+    expect(html).toContain('AB');
+    expect(html).toContain('#1976d2');
+    expect(html).toContain('Anna Bauer');
+    expect(html).toContain('opacity:1');
+  });
+
+  it('reflects faded opacity in the wrapper style', () => {
+    const html = buildIconHtml({
+      initials: 'XY',
+      color: '#000',
+      displayName: 'X Y',
+      opacity: 0.5,
+    });
+    expect(html).toContain('opacity:0.5');
+  });
+});
+
+describe('LiveLocationMarker rendering decisions', () => {
+  it('returns null when opacity is zero (stale)', async () => {
+    const { default: LiveLocationMarker } = await import('./LiveLocationMarker');
+    const { Timestamp } = await import('firebase/firestore');
+    const { STALE_HARD_CUTOFF_MS } = await import('../../../common/liveLocation');
+    const now = 1_000_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const stale = now - STALE_HARD_CUTOFF_MS - 1;
+    const loc = {
+      id: 'u1',
+      uid: 'u1',
+      name: 'User One',
+      email: 'u1@example.com',
+      lat: 0,
+      lng: 0,
+      updatedAt: Timestamp.fromMillis(stale),
+      expiresAt: Timestamp.fromMillis(stale + 1_000_000),
+      updatedAtMs: stale,
+    };
+
+    // Render without a MapContainer; component should bail out and return null
+    // before any react-leaflet primitives mount.
+    const { render } = await import('@testing-library/react');
+    const { container } = render(<LiveLocationMarker loc={loc} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/Map/markers/LiveLocationMarker.tsx
+++ b/src/components/Map/markers/LiveLocationMarker.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import L from 'leaflet';
+import { useEffect, useMemo, useState } from 'react';
+import { Marker, Popup } from 'react-leaflet';
+import {
+  computeInitials,
+  computeOpacity,
+  pickAvatarColor,
+} from '../../../common/liveLocation';
+import type { DisplayableLiveLocation } from '../../../hooks/useLiveLocations';
+
+export const formatRelative = (ms: number): string => {
+  const ageSec = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (ageSec < 60) return `vor ${ageSec} s`;
+  const m = Math.round(ageSec / 60);
+  return `vor ${m} min`;
+};
+
+export interface IconHtmlOptions {
+  initials: string;
+  color: string;
+  displayName: string;
+  opacity: number;
+}
+
+/** Pure helper: builds the divIcon HTML so it can be unit-tested. */
+export function buildIconHtml({
+  initials,
+  color,
+  displayName,
+  opacity,
+}: IconHtmlOptions): string {
+  return `
+    <div style="display:flex;align-items:center;gap:4px;opacity:${opacity};pointer-events:auto;">
+      <div style="
+        width:32px;height:32px;border-radius:50%;
+        background:${color};color:#fff;
+        display:flex;align-items:center;justify-content:center;
+        font:bold 12px sans-serif;
+        border:2px solid #fff;box-shadow:0 1px 2px rgba(0,0,0,.4);
+      ">${initials}</div>
+      <div style="
+        background:rgba(255,255,255,.85);
+        padding:2px 6px;border-radius:4px;
+        font:11px sans-serif;color:#222;white-space:nowrap;
+        box-shadow:0 1px 2px rgba(0,0,0,.2);
+      ">${displayName}</div>
+    </div>`;
+}
+
+export default function LiveLocationMarker({
+  loc,
+}: {
+  loc: DisplayableLiveLocation;
+}) {
+  const [, force] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => force((n) => n + 1), 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const opacity = computeOpacity(loc.updatedAtMs);
+  const initials = computeInitials(loc.name, loc.email);
+  const color = pickAvatarColor(loc.uid);
+  const displayName = loc.name || loc.email;
+
+  const icon = useMemo(
+    () =>
+      L.divIcon({
+        className: '',
+        html: buildIconHtml({ initials, color, displayName, opacity }),
+        iconSize: [120, 32],
+        iconAnchor: [16, 16],
+        popupAnchor: [0, -16],
+      }),
+    [opacity, initials, color, displayName]
+  );
+
+  if (opacity <= 0) return null;
+
+  return (
+    <Marker position={{ lat: loc.lat, lng: loc.lng }} icon={icon}>
+      <Popup>
+        <strong>{displayName}</strong>
+        <br />
+        zuletzt aktualisiert {formatRelative(loc.updatedAtMs)}
+      </Popup>
+    </Marker>
+  );
+}

--- a/src/components/providers/AppProviders.tsx
+++ b/src/components/providers/AppProviders.tsx
@@ -39,6 +39,9 @@ const GpsProvider = dynamic(() => import('./GpsProvider'), {
 const DebugLoggingProvider = dynamic(() => import('./DebugLoggingProvider'), {
   ssr: false,
 });
+const LiveLocationProvider = dynamic(() => import('./LiveLocationProvider'), {
+  ssr: false,
+});
 const PermissionOnboardingProvider = dynamic(
   () => import('../permissions/PermissionOnboardingProvider'),
   { ssr: false }
@@ -59,25 +62,27 @@ function LogedinApp({ children }: AppProps) {
       <PositionProvider>
         <RadiacodeProvider>
           <GpsProvider>
-            <DebugLoggingProvider>
-              <MapEditorProvider>
-                <FirecallLayerProvider>
-                  <AppDrawer isOpen={isDrawerOpen} setIsOpen={setIsDrawerOpen} />
+            <LiveLocationProvider>
+              <DebugLoggingProvider>
+                <MapEditorProvider>
+                  <FirecallLayerProvider>
+                    <AppDrawer isOpen={isDrawerOpen} setIsOpen={setIsDrawerOpen} />
 
-                  <HeaderBar
-                    isDrawerOpen={isDrawerOpen}
-                    setIsDrawerOpen={setIsDrawerOpen}
-                  />
-                  <ChatMessageDisplay />
-                  <Box
-                    className="print-content-root"
-                    sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}
-                  >
-                    {children}
-                  </Box>
-                </FirecallLayerProvider>
-              </MapEditorProvider>
-            </DebugLoggingProvider>
+                    <HeaderBar
+                      isDrawerOpen={isDrawerOpen}
+                      setIsDrawerOpen={setIsDrawerOpen}
+                    />
+                    <ChatMessageDisplay />
+                    <Box
+                      className="print-content-root"
+                      sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}
+                    >
+                      {children}
+                    </Box>
+                  </FirecallLayerProvider>
+                </MapEditorProvider>
+              </DebugLoggingProvider>
+            </LiveLocationProvider>
           </GpsProvider>
         </RadiacodeProvider>
       </PositionProvider>

--- a/src/components/providers/LiveLocationProvider.test.tsx
+++ b/src/components/providers/LiveLocationProvider.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import type { GeoPositionObject } from '../../common/geo';
+import type { PositionInfo } from '../../hooks/usePosition';
+
+// --- Mocks ---------------------------------------------------------------
+
+vi.mock('../firebase/firebase', () => ({
+  default: {},
+  firestore: { type: 'mock-firestore' },
+}));
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(() => ({ type: 'mock-doc-ref' })),
+  serverTimestamp: vi.fn(() => ({ type: 'mock-server-ts' })),
+  Timestamp: {
+    fromMillis: vi.fn((ms: number) => ({ type: 'mock-timestamp', ms })),
+  },
+}));
+
+vi.mock('../../lib/firestoreClient', () => ({
+  setDoc: vi.fn(() => Promise.resolve()),
+  deleteDoc: vi.fn(() => Promise.resolve()),
+}));
+
+const nativeStartLiveShare = vi.fn((_opts: unknown) => Promise.resolve());
+const nativeStopLiveShare = vi.fn(() => Promise.resolve());
+const isNativeGpsTrackingAvailable = vi.fn(() => false);
+
+vi.mock('../../hooks/recording/nativeGpsTrackBridge', () => ({
+  isNativeGpsTrackingAvailable: () => isNativeGpsTrackingAvailable(),
+  nativeStartLiveShare: (opts: unknown) => nativeStartLiveShare(opts),
+  nativeStopLiveShare: () => nativeStopLiveShare(),
+}));
+
+// PositionContext / useFirecall(Id) / useFirebaseLogin are all simple
+// hooks we can swap with controllable mocks.
+const positionState = {
+  position: { lat: 47.9, lng: 16.85 } as GeoPositionObject,
+  isPositionSet: true,
+  location: undefined as GeolocationPosition | undefined,
+};
+function getPositionInfo(): PositionInfo {
+  return [
+    positionState.position,
+    positionState.isPositionSet,
+    positionState.location,
+    () => {},
+    false,
+  ];
+}
+vi.mock('./PositionProvider', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PositionProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  usePositionContext: () => getPositionInfo(),
+}));
+
+const loginState = {
+  uid: 'user-1' as string | undefined,
+  email: 'paul@example.com' as string | undefined,
+  displayName: 'Paul Wölfel' as string | undefined,
+};
+vi.mock('../../hooks/useFirebaseLogin', () => ({
+  __esModule: true,
+  default: () => ({ ...loginState }),
+}));
+
+const firecallState = {
+  id: 'fc-A',
+  name: 'Brand B7',
+};
+vi.mock('../../hooks/useFirecall', () => ({
+  __esModule: true,
+  default: () => ({ id: firecallState.id, name: firecallState.name }),
+  useFirecall: () => ({ id: firecallState.id, name: firecallState.name }),
+  useFirecallId: () => firecallState.id,
+}));
+
+// useLiveLocationSettings is fine to use as-is — but we don't want it to
+// touch localStorage between tests, so reset before each test.
+
+// --- Imports under test --------------------------------------------------
+import {
+  LiveLocationProvider,
+  useLiveLocationContext,
+} from './LiveLocationProvider';
+
+// --- Helpers -------------------------------------------------------------
+
+function Probe({
+  onValue,
+}: {
+  onValue: (v: ReturnType<typeof useLiveLocationContext>) => void;
+}) {
+  const ctx = useLiveLocationContext();
+  onValue(ctx);
+  return <div data-testid="sharing">{ctx.isSharing ? 'on' : 'off'}</div>;
+}
+
+function renderProvider() {
+  const values: ReturnType<typeof useLiveLocationContext>[] = [];
+  const utils = render(
+    <LiveLocationProvider>
+      <Probe onValue={(v) => values.push(v)} />
+    </LiveLocationProvider>,
+  );
+  return { ...utils, values };
+}
+
+// --- Tests ---------------------------------------------------------------
+
+describe('LiveLocationProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isNativeGpsTrackingAvailable.mockReturnValue(false);
+    positionState.position = { lat: 47.9, lng: 16.85 };
+    positionState.isPositionSet = true;
+    positionState.location = undefined;
+    loginState.uid = 'user-1';
+    loginState.email = 'paul@example.com';
+    loginState.displayName = 'Paul Wölfel';
+    firecallState.id = 'fc-A';
+    firecallState.name = 'Brand B7';
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  it('mounts with isSharing=false and exposes settings + canShare', () => {
+    const { values } = renderProvider();
+    const ctx = values.at(-1)!;
+    expect(ctx.isSharing).toBe(false);
+    expect(typeof ctx.start).toBe('function');
+    expect(typeof ctx.stop).toBe('function');
+    expect(ctx.canShare).toBe(true);
+    expect(ctx.settings.heartbeatMs).toBeGreaterThan(0);
+    expect(ctx.settings.distanceM).toBeGreaterThan(0);
+  });
+
+  it('throws when used outside provider', () => {
+    const Consumer = () => {
+      useLiveLocationContext();
+      return null;
+    };
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<Consumer />)).toThrow(/LiveLocationProvider/);
+    errSpy.mockRestore();
+  });
+
+  it('start() flips isSharing to true; stop() flips it back', async () => {
+    const { values } = renderProvider();
+
+    await act(async () => {
+      await values.at(-1)!.start();
+    });
+    expect(values.at(-1)!.isSharing).toBe(true);
+
+    await act(async () => {
+      await values.at(-1)!.stop();
+    });
+    expect(values.at(-1)!.isSharing).toBe(false);
+  });
+
+  it('canShare is false when uid missing', () => {
+    loginState.uid = undefined;
+    const { values } = renderProvider();
+    expect(values.at(-1)!.canShare).toBe(false);
+  });
+
+  it('canShare is false when firecallId is "unknown"', () => {
+    firecallState.id = 'unknown';
+    const { values } = renderProvider();
+    expect(values.at(-1)!.canShare).toBe(false);
+  });
+
+  it('canShare is false when no position is set', () => {
+    positionState.isPositionSet = false;
+    const { values } = renderProvider();
+    expect(values.at(-1)!.canShare).toBe(false);
+  });
+
+  it('start() does nothing when no firecall is selected', async () => {
+    firecallState.id = 'unknown';
+    const { values } = renderProvider();
+    await act(async () => {
+      await values.at(-1)!.start();
+    });
+    expect(values.at(-1)!.isSharing).toBe(false);
+    expect(nativeStartLiveShare).not.toHaveBeenCalled();
+  });
+
+  it('calls native bridge start when native tracking is available', async () => {
+    isNativeGpsTrackingAvailable.mockReturnValue(true);
+    const { values } = renderProvider();
+    await act(async () => {
+      await values.at(-1)!.start();
+    });
+    expect(nativeStartLiveShare).toHaveBeenCalledTimes(1);
+    const opts = nativeStartLiveShare.mock.calls[0][0] as unknown as {
+      firecallId: string;
+      uid: string;
+      firecallName: string;
+    };
+    expect(opts.firecallId).toBe('fc-A');
+    expect(opts.uid).toBe('user-1');
+    expect(opts.firecallName).toBe('Brand B7');
+  });
+
+  it('calls native bridge stop on stop() when native tracking is available', async () => {
+    isNativeGpsTrackingAvailable.mockReturnValue(true);
+    const { values } = renderProvider();
+    await act(async () => {
+      await values.at(-1)!.start();
+    });
+    await act(async () => {
+      await values.at(-1)!.stop();
+    });
+    expect(nativeStopLiveShare).toHaveBeenCalled();
+  });
+
+  it('does NOT call native bridge when not available', async () => {
+    isNativeGpsTrackingAvailable.mockReturnValue(false);
+    const { values } = renderProvider();
+    await act(async () => {
+      await values.at(-1)!.start();
+    });
+    await act(async () => {
+      await values.at(-1)!.stop();
+    });
+    expect(nativeStartLiveShare).not.toHaveBeenCalled();
+    expect(nativeStopLiveShare).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/providers/LiveLocationProvider.tsx
+++ b/src/components/providers/LiveLocationProvider.tsx
@@ -23,6 +23,45 @@ import {
 } from '../../hooks/useLiveLocationSettings';
 import { usePositionContext } from './PositionProvider';
 
+const ACTIVE_STORAGE_KEY = 'liveLocationActive/v1';
+// Auto-resume on reload only if the recorded session is recent enough.
+const MAX_RESUME_AGE_MS = 12 * 60 * 60 * 1000;
+
+interface PersistedActive {
+  firecallId: string;
+  uid: string;
+  startedAt: number;
+}
+
+function loadActive(): PersistedActive | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(ACTIVE_STORAGE_KEY);
+    if (!raw) return null;
+    const v = JSON.parse(raw) as PersistedActive;
+    if (
+      typeof v.firecallId !== 'string' ||
+      typeof v.uid !== 'string' ||
+      typeof v.startedAt !== 'number'
+    ) {
+      return null;
+    }
+    if (Date.now() - v.startedAt > MAX_RESUME_AGE_MS) return null;
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+function saveActive(v: PersistedActive | null): void {
+  if (typeof window === 'undefined') return;
+  if (v) {
+    window.localStorage.setItem(ACTIVE_STORAGE_KEY, JSON.stringify(v));
+  } else {
+    window.localStorage.removeItem(ACTIVE_STORAGE_KEY);
+  }
+}
+
 export interface LiveLocationContextValue {
   isSharing: boolean;
   settings: LiveLocationSettings;
@@ -71,6 +110,7 @@ export function LiveLocationProvider({ children }: { children: React.ReactNode }
   useEffect(() => {
     if (previousFirecallRef.current !== firecallId && isSharing) {
       void deleteOwn();
+      saveActive(null);
       // External state change (firecall switch) requires reactive teardown.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsSharing(false);
@@ -81,25 +121,10 @@ export function LiveLocationProvider({ children }: { children: React.ReactNode }
     previousFirecallRef.current = firecallId;
   }, [firecallId, isSharing, deleteOwn]);
 
-  // Best-effort cleanup on unmount + beforeunload.
-  // NOTE: This unconditionally deletes the doc on unmount. Task 10 will
-  // refine this so we keep the doc alive while a native foreground service
-  // is still pushing updates.
-  useEffect(() => {
-    if (!isSharing) return;
-    const handler = () => {
-      void deleteOwn();
-    };
-    window.addEventListener('beforeunload', handler);
-    return () => {
-      window.removeEventListener('beforeunload', handler);
-      void deleteOwn();
-    };
-  }, [isSharing, deleteOwn]);
-
   const start = useCallback(async () => {
     if (!uid || !firecallId || firecallId === 'unknown') return;
     setIsSharing(true);
+    saveActive({ firecallId, uid, startedAt: Date.now() });
     if (isNativeGpsTrackingAvailable()) {
       await nativeStartLiveShare({
         firecallId,
@@ -117,11 +142,36 @@ export function LiveLocationProvider({ children }: { children: React.ReactNode }
 
   const stop = useCallback(async () => {
     setIsSharing(false);
+    saveActive(null);
     await deleteOwn();
     if (isNativeGpsTrackingAvailable()) {
       await nativeStopLiveShare().catch(() => {});
     }
   }, [deleteOwn]);
+
+  // Auto-resume on mount: if localStorage says we were sharing for the
+  // current (firecallId, uid) and the recorded session is recent enough,
+  // restart sharing without re-confirming. Survives page reloads.
+  // Stale docs are cleaned by the Firestore TTL (1 h) and the 5-min UI hide,
+  // so we deliberately do NOT delete the doc on unmount/beforeunload.
+  const resumedRef = useRef(false);
+  useEffect(() => {
+    if (resumedRef.current) return;
+    if (!uid || !firecallId || firecallId === 'unknown') return;
+    const persisted = loadActive();
+    if (!persisted) return;
+    if (persisted.uid !== uid) return;
+    if (persisted.firecallId !== firecallId) {
+      // Drop entries from a different firecall.
+      saveActive(null);
+      return;
+    }
+    resumedRef.current = true;
+    const t = setTimeout(() => {
+      void start();
+    }, 0);
+    return () => clearTimeout(t);
+  }, [uid, firecallId, start]);
 
   const canShare = isPositionSet && !!uid && firecallId !== 'unknown';
 

--- a/src/components/providers/LiveLocationProvider.tsx
+++ b/src/components/providers/LiveLocationProvider.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  isNativeGpsTrackingAvailable,
+  nativeStartLiveShare,
+  nativeStopLiveShare,
+} from '../../hooks/recording/nativeGpsTrackBridge';
+import useFirebaseLogin from '../../hooks/useFirebaseLogin';
+import { useFirecall, useFirecallId } from '../../hooks/useFirecall';
+import { useLiveLocationShare } from '../../hooks/useLiveLocationShare';
+import {
+  LiveLocationSettings,
+  useLiveLocationSettings,
+} from '../../hooks/useLiveLocationSettings';
+import { usePositionContext } from './PositionProvider';
+
+export interface LiveLocationContextValue {
+  isSharing: boolean;
+  settings: LiveLocationSettings;
+  setSettings: (s: LiveLocationSettings) => void;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  canShare: boolean;
+}
+
+const LiveLocationContext = createContext<LiveLocationContextValue | null>(null);
+
+export function LiveLocationProvider({ children }: { children: React.ReactNode }) {
+  const [position, isPositionSet, location] = usePositionContext();
+  const { uid, email, displayName } = useFirebaseLogin();
+  const firecallId = useFirecallId();
+  const firecall = useFirecall();
+
+  const { settings, setSettings } = useLiveLocationSettings();
+  const [isSharing, setIsSharing] = useState(false);
+
+  const identity = useMemo(() => {
+    if (!isSharing || !uid || !firecallId || firecallId === 'unknown') {
+      return null;
+    }
+    return {
+      firecallId,
+      uid,
+      name: displayName || email || '',
+      email: email ?? '',
+    };
+  }, [isSharing, uid, firecallId, displayName, email]);
+
+  const { maybeSend, deleteOwn } = useLiveLocationShare(identity, settings);
+
+  // Push position updates while sharing.
+  useEffect(() => {
+    if (!isSharing || !isPositionSet) return;
+    void maybeSend(position, location);
+  }, [isSharing, isPositionSet, position, location, maybeSend]);
+
+  // Auto-stop on firecall change: when the active firecall changes while
+  // we are still sharing, tear down (delete the doc on the OLD path inside
+  // useLiveLocationShare which still holds the old identity, then flip to
+  // not-sharing). We deliberately leave restart up to the user.
+  const previousFirecallRef = useRef(firecallId);
+  useEffect(() => {
+    if (previousFirecallRef.current !== firecallId && isSharing) {
+      void deleteOwn();
+      // External state change (firecall switch) requires reactive teardown.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsSharing(false);
+      if (isNativeGpsTrackingAvailable()) {
+        void nativeStopLiveShare().catch(() => {});
+      }
+    }
+    previousFirecallRef.current = firecallId;
+  }, [firecallId, isSharing, deleteOwn]);
+
+  // Best-effort cleanup on unmount + beforeunload.
+  // NOTE: This unconditionally deletes the doc on unmount. Task 10 will
+  // refine this so we keep the doc alive while a native foreground service
+  // is still pushing updates.
+  useEffect(() => {
+    if (!isSharing) return;
+    const handler = () => {
+      void deleteOwn();
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => {
+      window.removeEventListener('beforeunload', handler);
+      void deleteOwn();
+    };
+  }, [isSharing, deleteOwn]);
+
+  const start = useCallback(async () => {
+    if (!uid || !firecallId || firecallId === 'unknown') return;
+    setIsSharing(true);
+    if (isNativeGpsTrackingAvailable()) {
+      await nativeStartLiveShare({
+        firecallId,
+        uid,
+        name: displayName || email || '',
+        email: email ?? '',
+        intervalMs: settings.heartbeatMs,
+        distanceM: settings.distanceM,
+        firecallName: firecall.name,
+      }).catch((err) =>
+        console.warn('[liveLocation] native start failed', err),
+      );
+    }
+  }, [uid, firecallId, displayName, email, settings, firecall.name]);
+
+  const stop = useCallback(async () => {
+    setIsSharing(false);
+    await deleteOwn();
+    if (isNativeGpsTrackingAvailable()) {
+      await nativeStopLiveShare().catch(() => {});
+    }
+  }, [deleteOwn]);
+
+  const canShare = isPositionSet && !!uid && firecallId !== 'unknown';
+
+  const value: LiveLocationContextValue = {
+    isSharing,
+    settings,
+    setSettings,
+    start,
+    stop,
+    canShare,
+  };
+
+  return (
+    <LiveLocationContext.Provider value={value}>
+      {children}
+    </LiveLocationContext.Provider>
+  );
+}
+
+export default LiveLocationProvider;
+
+export function useLiveLocationContext(): LiveLocationContextValue {
+  const ctx = useContext(LiveLocationContext);
+  if (!ctx) {
+    throw new Error(
+      'useLiveLocationContext must be used within LiveLocationProvider',
+    );
+  }
+  return ctx;
+}

--- a/src/components/providers/LiveLocationProvider.tsx
+++ b/src/components/providers/LiveLocationProvider.tsx
@@ -151,9 +151,13 @@ export function LiveLocationProvider({ children }: { children: React.ReactNode }
 
   // Auto-resume on mount: if localStorage says we were sharing for the
   // current (firecallId, uid) and the recorded session is recent enough,
-  // restart sharing without re-confirming. Survives page reloads.
+  // restart sharing without re-confirming. Survives page reloads, Fast
+  // Refresh, and the soft remounts that auth-token rotation triggers.
   // Stale docs are cleaned by the Firestore TTL (1 h) and the 5-min UI hide,
   // so we deliberately do NOT delete the doc on unmount/beforeunload.
+  // queueMicrotask survives an effect re-run (no cancel-on-cleanup race like
+  // setTimeout has), so we still fire exactly once even if `start`'s identity
+  // changes mid-flight (e.g. when settings or firecall.name resolve).
   const resumedRef = useRef(false);
   useEffect(() => {
     if (resumedRef.current) return;
@@ -167,10 +171,9 @@ export function LiveLocationProvider({ children }: { children: React.ReactNode }
       return;
     }
     resumedRef.current = true;
-    const t = setTimeout(() => {
+    queueMicrotask(() => {
       void start();
-    }, 0);
-    return () => clearTimeout(t);
+    });
   }, [uid, firecallId, start]);
 
   const canShare = isPositionSet && !!uid && firecallId !== 'unknown';

--- a/src/hooks/radiacode/radiacodeNotification.ts
+++ b/src/hooks/radiacode/radiacodeNotification.ts
@@ -75,6 +75,11 @@ export interface RadiacodeNotificationPlugin {
   startGpsTrack(opts: Record<string, unknown>): Promise<void>;
   stopGpsTrack(): Promise<void>;
 
+  // Phase 5: Live Location Sharing
+  startLiveShare(opts: Record<string, unknown>): Promise<void>;
+  stopLiveShare(): Promise<void>;
+  updateLiveShareSettings(opts: Record<string, unknown>): Promise<void>;
+
   // Common Listeners
   addListener(
     event: 'disconnectRequested',

--- a/src/hooks/recording/nativeGpsTrackBridge.ts
+++ b/src/hooks/recording/nativeGpsTrackBridge.ts
@@ -43,3 +43,43 @@ export async function nativeStopGpsTrack(): Promise<void> {
   console.log('[GpsTrack/native] stopGpsTrack');
   await GpsTrack.stopGpsTrack();
 }
+
+export interface NativeLiveShareOpts {
+  firecallId: string;
+  uid: string;
+  name: string;
+  email: string;
+  intervalMs: number;
+  distanceM: number;
+  firecallName: string;
+}
+
+export async function nativeStartLiveShare(
+  opts: NativeLiveShareOpts,
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    firecallId: opts.firecallId,
+    uid: opts.uid,
+    name: opts.name,
+    email: opts.email,
+    intervalMs: opts.intervalMs,
+    distanceM: opts.distanceM,
+    firecallName: opts.firecallName,
+    firestoreDb: process.env.NEXT_PUBLIC_FIRESTORE_DB || '(default)',
+  };
+  console.log('[GpsTrack/native] startLiveShare', payload);
+  await GpsTrack.startLiveShare(payload);
+}
+
+export async function nativeStopLiveShare(): Promise<void> {
+  console.log('[GpsTrack/native] stopLiveShare');
+  await GpsTrack.stopLiveShare();
+}
+
+export async function nativeUpdateLiveShareSettings(opts: {
+  intervalMs: number;
+  distanceM: number;
+}): Promise<void> {
+  console.log('[GpsTrack/native] updateLiveShareSettings', opts);
+  await GpsTrack.updateLiveShareSettings(opts as Record<string, unknown>);
+}

--- a/src/hooks/useLiveLocationSettings.test.ts
+++ b/src/hooks/useLiveLocationSettings.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useLiveLocationSettings,
+  DEFAULT_HEARTBEAT_MS,
+  DEFAULT_DISTANCE_M,
+  HEARTBEAT_MIN_MS,
+  HEARTBEAT_MAX_MS,
+  DISTANCE_MIN_M,
+  DISTANCE_MAX_M,
+  STORAGE_KEY,
+} from './useLiveLocationSettings';
+
+describe('useLiveLocationSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns defaults when nothing in storage', () => {
+    const { result } = renderHook(() => useLiveLocationSettings());
+    expect(result.current.settings.heartbeatMs).toBe(DEFAULT_HEARTBEAT_MS);
+    expect(result.current.settings.distanceM).toBe(DEFAULT_DISTANCE_M);
+  });
+
+  it('loads saved settings', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ heartbeatMs: 60_000, distanceM: 50 })
+    );
+    const { result } = renderHook(() => useLiveLocationSettings());
+    expect(result.current.settings.heartbeatMs).toBe(60_000);
+    expect(result.current.settings.distanceM).toBe(50);
+  });
+
+  it('clamps out-of-range values to min/max on save', () => {
+    const { result } = renderHook(() => useLiveLocationSettings());
+    act(() => {
+      result.current.setSettings({ heartbeatMs: 5_000, distanceM: 1_000 });
+    });
+    expect(result.current.settings.heartbeatMs).toBe(HEARTBEAT_MIN_MS);
+    expect(result.current.settings.distanceM).toBe(DISTANCE_MAX_M);
+    // Reference the remaining bound constants to keep them part of the public surface.
+    expect(HEARTBEAT_MAX_MS).toBeGreaterThan(HEARTBEAT_MIN_MS);
+    expect(DISTANCE_MIN_M).toBeLessThan(DISTANCE_MAX_M);
+  });
+
+  it('persists changes to localStorage', () => {
+    const { result } = renderHook(() => useLiveLocationSettings());
+    act(() => {
+      result.current.setSettings({ heartbeatMs: 45_000, distanceM: 25 });
+    });
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.heartbeatMs).toBe(45_000);
+    expect(parsed.distanceM).toBe(25);
+  });
+});

--- a/src/hooks/useLiveLocationSettings.ts
+++ b/src/hooks/useLiveLocationSettings.ts
@@ -1,0 +1,64 @@
+'use client';
+import { useCallback, useState } from 'react';
+
+export const STORAGE_KEY = 'liveLocationSettings/v1';
+
+export const DEFAULT_HEARTBEAT_MS = 30_000;
+export const DEFAULT_DISTANCE_M = 20;
+export const HEARTBEAT_MIN_MS = 10_000;
+export const HEARTBEAT_MAX_MS = 120_000;
+export const DISTANCE_MIN_M = 5;
+export const DISTANCE_MAX_M = 100;
+
+export interface LiveLocationSettings {
+  heartbeatMs: number;
+  distanceM: number;
+}
+
+const DEFAULTS: LiveLocationSettings = {
+  heartbeatMs: DEFAULT_HEARTBEAT_MS,
+  distanceM: DEFAULT_DISTANCE_M,
+};
+
+const clamp = (n: number, min: number, max: number) =>
+  Math.min(Math.max(n, min), max);
+
+function load(): LiveLocationSettings {
+  if (typeof window === 'undefined') return DEFAULTS;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    const parsed = JSON.parse(raw) as Partial<LiveLocationSettings>;
+    return {
+      heartbeatMs: clamp(
+        Number(parsed.heartbeatMs ?? DEFAULT_HEARTBEAT_MS),
+        HEARTBEAT_MIN_MS,
+        HEARTBEAT_MAX_MS
+      ),
+      distanceM: clamp(
+        Number(parsed.distanceM ?? DEFAULT_DISTANCE_M),
+        DISTANCE_MIN_M,
+        DISTANCE_MAX_M
+      ),
+    };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function useLiveLocationSettings() {
+  const [settings, setSettingsState] = useState<LiveLocationSettings>(load);
+
+  const setSettings = useCallback((next: LiveLocationSettings) => {
+    const clamped: LiveLocationSettings = {
+      heartbeatMs: clamp(next.heartbeatMs, HEARTBEAT_MIN_MS, HEARTBEAT_MAX_MS),
+      distanceM: clamp(next.distanceM, DISTANCE_MIN_M, DISTANCE_MAX_M),
+    };
+    setSettingsState(clamped);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(clamped));
+    }
+  }, []);
+
+  return { settings, setSettings };
+}

--- a/src/hooks/useLiveLocationShare.test.ts
+++ b/src/hooks/useLiveLocationShare.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../components/firebase/firebase', () => ({
+  default: {},
+  firestore: { type: 'mock-firestore' },
+}));
+
+vi.mock('../lib/firestoreClient', () => ({
+  setDoc: vi.fn(() => Promise.resolve()),
+  deleteDoc: vi.fn(() => Promise.resolve()),
+}));
+
+import { shouldSendUpdate, distanceMeters } from './useLiveLocationShare';
+
+const settings = { heartbeatMs: 30_000, distanceM: 20 };
+
+describe('shouldSendUpdate (OR logic)', () => {
+  it('triggers on first call (no lastSent)', () => {
+    expect(
+      shouldSendUpdate(undefined, 1_000, undefined, { lat: 0, lng: 0 }, settings)
+    ).toBe(true);
+  });
+
+  it('triggers when heartbeat elapsed without movement', () => {
+    expect(
+      shouldSendUpdate(0, 30_001, { lat: 0, lng: 0 }, { lat: 0, lng: 0 }, settings)
+    ).toBe(true);
+  });
+
+  it('does not trigger before heartbeat without movement', () => {
+    expect(
+      shouldSendUpdate(0, 29_000, { lat: 0, lng: 0 }, { lat: 0, lng: 0 }, settings)
+    ).toBe(false);
+  });
+
+  it('triggers on distance threshold even before heartbeat', () => {
+    // 0.0002 deg lat ≈ 22 m
+    expect(
+      shouldSendUpdate(
+        0,
+        5_000,
+        { lat: 0, lng: 0 },
+        { lat: 0.0002, lng: 0 },
+        settings
+      )
+    ).toBe(true);
+  });
+
+  it('does not trigger on small movement before heartbeat', () => {
+    // 0.00005 deg lat ≈ 5.5 m
+    expect(
+      shouldSendUpdate(
+        0,
+        5_000,
+        { lat: 0, lng: 0 },
+        { lat: 0.00005, lng: 0 },
+        settings
+      )
+    ).toBe(false);
+  });
+});
+
+describe('distanceMeters', () => {
+  it('is roughly 0 for identical coords', () => {
+    expect(distanceMeters({ lat: 47, lng: 16 }, { lat: 47, lng: 16 })).toBeLessThan(
+      0.5
+    );
+  });
+  it('approximates 1 deg lat ≈ 111 km', () => {
+    const d = distanceMeters({ lat: 47, lng: 16 }, { lat: 48, lng: 16 });
+    expect(d).toBeGreaterThan(110_000);
+    expect(d).toBeLessThan(112_000);
+  });
+});

--- a/src/hooks/useLiveLocationShare.ts
+++ b/src/hooks/useLiveLocationShare.ts
@@ -90,18 +90,28 @@ export function useLiveLocationShare(
         LIVE_LOCATION_COLLECTION_ID,
         identity.uid
       );
-      await setDoc(ref, {
+      const payload: Record<string, unknown> = {
         uid: identity.uid,
         name: identity.name,
         email: identity.email,
         lat: pos.lat,
         lng: pos.lng,
-        accuracy: location?.coords.accuracy,
-        heading: location?.coords.heading ?? undefined,
-        speed: location?.coords.speed ?? undefined,
         updatedAt: serverTimestamp(),
         expiresAt: Timestamp.fromMillis(Date.now() + TTL_EXPIRY_MS),
-      });
+      };
+      const accuracy = location?.coords.accuracy;
+      if (typeof accuracy === 'number' && Number.isFinite(accuracy)) {
+        payload.accuracy = accuracy;
+      }
+      const heading = location?.coords.heading;
+      if (typeof heading === 'number' && Number.isFinite(heading)) {
+        payload.heading = heading;
+      }
+      const speed = location?.coords.speed;
+      if (typeof speed === 'number' && Number.isFinite(speed)) {
+        payload.speed = speed;
+      }
+      await setDoc(ref, payload);
       lastSentMsRef.current = now;
       lastPosRef.current = { lat: pos.lat, lng: pos.lng };
     },

--- a/src/hooks/useLiveLocationShare.ts
+++ b/src/hooks/useLiveLocationShare.ts
@@ -1,0 +1,134 @@
+'use client';
+import { doc, serverTimestamp, Timestamp } from 'firebase/firestore';
+import { useCallback, useEffect, useRef } from 'react';
+import { firestore } from '../components/firebase/firebase';
+import { deleteDoc, setDoc } from '../lib/firestoreClient';
+import { FIRECALL_COLLECTION_ID } from '../components/firebase/firestore';
+import {
+  LIVE_LOCATION_COLLECTION_ID,
+  TTL_EXPIRY_MS,
+} from '../common/liveLocation';
+import type { LiveLocationSettings } from './useLiveLocationSettings';
+import type { GeoPositionObject } from '../common/geo';
+
+interface ShareIdentity {
+  firecallId: string;
+  uid: string;
+  name: string;
+  email: string;
+}
+
+export function distanceMeters(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): number {
+  const R = 6_371_000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const x =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(x));
+}
+
+export function shouldSendUpdate(
+  lastSentMs: number | undefined,
+  nowMs: number,
+  lastPos: { lat: number; lng: number } | undefined,
+  currentPos: { lat: number; lng: number },
+  settings: LiveLocationSettings
+): boolean {
+  if (lastSentMs === undefined || !lastPos) return true;
+  const elapsed = nowMs - lastSentMs;
+  if (elapsed >= settings.heartbeatMs) return true;
+  if (distanceMeters(lastPos, currentPos) >= settings.distanceM) return true;
+  return false;
+}
+
+export interface LiveLocationShareApi {
+  /** Push a fresh position if the throttle gate allows. */
+  maybeSend: (
+    pos: GeoPositionObject,
+    location: GeolocationPosition | undefined
+  ) => Promise<void>;
+  /** Delete the user's doc (called on stop / firecall change). */
+  deleteOwn: () => Promise<void>;
+}
+
+export function useLiveLocationShare(
+  identity: ShareIdentity | null,
+  settings: LiveLocationSettings
+): LiveLocationShareApi {
+  const lastSentMsRef = useRef<number | undefined>(undefined);
+  const lastPosRef = useRef<{ lat: number; lng: number } | undefined>(undefined);
+
+  const maybeSend = useCallback(
+    async (
+      pos: GeoPositionObject,
+      location: GeolocationPosition | undefined
+    ) => {
+      if (!identity) return;
+      const now = Date.now();
+      if (
+        !shouldSendUpdate(
+          lastSentMsRef.current,
+          now,
+          lastPosRef.current,
+          { lat: pos.lat, lng: pos.lng },
+          settings
+        )
+      ) {
+        return;
+      }
+      const ref = doc(
+        firestore,
+        FIRECALL_COLLECTION_ID,
+        identity.firecallId,
+        LIVE_LOCATION_COLLECTION_ID,
+        identity.uid
+      );
+      await setDoc(ref, {
+        uid: identity.uid,
+        name: identity.name,
+        email: identity.email,
+        lat: pos.lat,
+        lng: pos.lng,
+        accuracy: location?.coords.accuracy,
+        heading: location?.coords.heading ?? undefined,
+        speed: location?.coords.speed ?? undefined,
+        updatedAt: serverTimestamp(),
+        expiresAt: Timestamp.fromMillis(Date.now() + TTL_EXPIRY_MS),
+      });
+      lastSentMsRef.current = now;
+      lastPosRef.current = { lat: pos.lat, lng: pos.lng };
+    },
+    [identity, settings]
+  );
+
+  const deleteOwn = useCallback(async () => {
+    if (!identity) return;
+    const ref = doc(
+      firestore,
+      FIRECALL_COLLECTION_ID,
+      identity.firecallId,
+      LIVE_LOCATION_COLLECTION_ID,
+      identity.uid
+    );
+    await deleteDoc(ref).catch((err) => {
+      console.warn('[liveLocation] deleteOwn failed', err);
+    });
+    lastSentMsRef.current = undefined;
+    lastPosRef.current = undefined;
+  }, [identity]);
+
+  // Reset internal state when identity (firecall/user) changes.
+  useEffect(() => {
+    lastSentMsRef.current = undefined;
+    lastPosRef.current = undefined;
+  }, [identity?.firecallId, identity?.uid]);
+
+  return { maybeSend, deleteOwn };
+}

--- a/src/hooks/useLiveLocations.test.ts
+++ b/src/hooks/useLiveLocations.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { Timestamp } from 'firebase/firestore';
+import { STALE_HARD_CUTOFF_MS } from '../common/liveLocation';
+
+const useFirebaseCollectionMock = vi.hoisted(() => vi.fn());
+const useFirecallIdMock = vi.hoisted(() => vi.fn(() => 'firecall-1'));
+const useFirebaseLoginMock = vi.hoisted(() => vi.fn(() => ({ uid: 'me' })));
+
+vi.mock('./useFirebaseCollection', () => ({
+  default: useFirebaseCollectionMock,
+}));
+
+vi.mock('./useFirecall', () => ({
+  useFirecallId: useFirecallIdMock,
+}));
+
+vi.mock('./useFirebaseLogin', () => ({
+  default: useFirebaseLoginMock,
+}));
+
+import { useLiveLocations } from './useLiveLocations';
+
+const makeTimestamp = (ms: number): Timestamp => Timestamp.fromMillis(ms);
+
+describe('useLiveLocations', () => {
+  beforeEach(() => {
+    useFirebaseCollectionMock.mockReset();
+    useFirecallIdMock.mockReset().mockReturnValue('firecall-1');
+    useFirebaseLoginMock.mockReset().mockReturnValue({ uid: 'me' });
+  });
+
+  it('returns empty array when no records', () => {
+    useFirebaseCollectionMock.mockReturnValue([]);
+    const { result } = renderHook(() => useLiveLocations());
+    expect(result.current).toEqual([]);
+  });
+
+  it('filters out the current user (own uid)', () => {
+    const now = Date.now();
+    useFirebaseCollectionMock.mockReturnValue([
+      {
+        id: 'me',
+        uid: 'me',
+        name: 'Me',
+        email: 'me@example.com',
+        lat: 0,
+        lng: 0,
+        updatedAt: makeTimestamp(now),
+        expiresAt: makeTimestamp(now + 1_000_000),
+      },
+      {
+        id: 'other',
+        uid: 'other',
+        name: 'Other',
+        email: 'other@example.com',
+        lat: 1,
+        lng: 1,
+        updatedAt: makeTimestamp(now),
+        expiresAt: makeTimestamp(now + 1_000_000),
+      },
+    ]);
+
+    const { result } = renderHook(() => useLiveLocations());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].uid).toBe('other');
+  });
+
+  it('filters out stale records older than 5 minutes', () => {
+    const now = Date.now();
+    const stale = now - STALE_HARD_CUTOFF_MS - 1_000;
+    useFirebaseCollectionMock.mockReturnValue([
+      {
+        id: 'fresh',
+        uid: 'fresh',
+        name: 'Fresh',
+        email: 'fresh@example.com',
+        lat: 0,
+        lng: 0,
+        updatedAt: makeTimestamp(now),
+        expiresAt: makeTimestamp(now + 1_000_000),
+      },
+      {
+        id: 'stale',
+        uid: 'stale',
+        name: 'Stale',
+        email: 'stale@example.com',
+        lat: 0,
+        lng: 0,
+        updatedAt: makeTimestamp(stale),
+        expiresAt: makeTimestamp(stale + 1_000_000),
+      },
+    ]);
+
+    const { result } = renderHook(() => useLiveLocations());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].uid).toBe('fresh');
+  });
+
+  it('exposes updatedAtMs derived from Firestore Timestamp', () => {
+    const ts = 1_700_000_000_000;
+    useFirebaseCollectionMock.mockReturnValue([
+      {
+        id: 'a',
+        uid: 'a',
+        name: 'A',
+        email: 'a@example.com',
+        lat: 0,
+        lng: 0,
+        updatedAt: makeTimestamp(ts),
+        expiresAt: makeTimestamp(ts + 1_000_000),
+      },
+    ]);
+    // Spy Date.now so the freshness check uses a value just after ts
+    vi.spyOn(Date, 'now').mockReturnValue(ts + 1_000);
+
+    const { result } = renderHook(() => useLiveLocations());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].updatedAtMs).toBe(ts);
+
+    vi.restoreAllMocks();
+  });
+
+  it('handles missing updatedAt by treating it as 0 (filtered as stale)', () => {
+    useFirebaseCollectionMock.mockReturnValue([
+      {
+        id: 'no-ts',
+        uid: 'no-ts',
+        name: 'NoTs',
+        email: 'nots@example.com',
+        lat: 0,
+        lng: 0,
+        // updatedAt missing
+      },
+    ]);
+
+    const { result } = renderHook(() => useLiveLocations());
+    expect(result.current).toEqual([]);
+  });
+});

--- a/src/hooks/useLiveLocations.ts
+++ b/src/hooks/useLiveLocations.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useMemo } from 'react';
+import useFirebaseCollection from './useFirebaseCollection';
+import { FIRECALL_COLLECTION_ID } from '../components/firebase/firestore';
+import {
+  LIVE_LOCATION_COLLECTION_ID,
+  isFresh,
+  LiveLocation,
+} from '../common/liveLocation';
+import { useFirecallId } from './useFirecall';
+import useFirebaseLogin from './useFirebaseLogin';
+
+export interface DisplayableLiveLocation extends LiveLocation {
+  id: string;
+  /** epoch ms of updatedAt for opacity calc */
+  updatedAtMs: number;
+}
+
+/** Narrow the unknown updatedAt field to a Firestore Timestamp duck-type. */
+function hasToMillis(value: unknown): value is { toMillis: () => number } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'toMillis' in value &&
+    typeof (value as { toMillis: unknown }).toMillis === 'function'
+  );
+}
+
+export function useLiveLocations(): DisplayableLiveLocation[] {
+  const firecallId = useFirecallId();
+  const { uid: myUid } = useFirebaseLogin();
+
+  const pathSegments = useMemo(
+    () => [firecallId, LIVE_LOCATION_COLLECTION_ID],
+    [firecallId]
+  );
+
+  const records = useFirebaseCollection<LiveLocation & { id: string }>({
+    collectionName: FIRECALL_COLLECTION_ID,
+    pathSegments,
+  });
+
+  return useMemo(() => {
+    if (!records) return [];
+    return records
+      .filter((r) => r.uid !== myUid)
+      .map((r) => {
+        const ts: unknown = r.updatedAt;
+        const ms = hasToMillis(ts) ? ts.toMillis() : 0;
+        return { ...r, id: r.id, updatedAtMs: ms };
+      })
+      .filter((r) => isFresh(r.updatedAtMs));
+  }, [records, myUid]);
+}


### PR DESCRIPTION
## Zusammenfassung

Einsatzkräfte können ihren Live-Standort innerhalb eines aktiven Firecalls für andere Berechtigte sichtbar machen. Andere User sehen die Standorte als Avatar-Marker mit Namens-Label auf der Einsatzkarte. Native Android unterstützt Background-Sharing via Foreground Service, integriert in den bestehenden GPS-Track-Service.

## Änderungen

- Neue Firestore-Subcollection `call/{firecallId}/livelocation/{uid}` mit TTL-Feld
- Schreib-Hook mit OR-Throttling (Default 30 s ODER 20 m, anpassbar)
- Eigene Leaflet-Layer „Live-Standorte" mit Avatar-Markern (Initialen + permanentem Namens-Label)
- FAB über `RecordButton` (auch außerhalb des Bearbeiten-Modus sichtbar), Click triggert ggf. Permission-Anfrage und öffnet Bestätigungs-Dialog mit erweiterten Settings
- Linke FAB-Stapelung: Position → Live-Sharing → Recording (8 px Abstand passend zur rechten Seite)
- localStorage-Persistenz + Auto-Resume nach Reload, Fast Refresh und Auth-Token-Rotation; Cleanup nur bei explizitem Stop oder Firecall-Wechsel
- Soft-Fade ab 2 min, hart-Cutoff bei 5 min, Stale-Docs durch Firestore TTL (1 h) bereinigt
- Native Android: bestehender Foreground Service um unabhängigen `liveShare`-Modus erweitert; Notification-Text reflektiert Track + Live-Share-Kombinationen
- Security Rules: Schreibzugriff auf eigene UID begrenzt, Read für alle Firecall-berechtigten User
- `kostenersatzVehicles` für alle authorized User lesbar (Voraussetzung für Einsatzort-Autocomplete)
- Doppelter `PositionProvider` entfernt (`PositionedMap` rein, `AppProviders` bleibt) — beseitigt Bug bei dem `canShare` immer `false` blieb

## Manueller Deployment-Schritt

Nach Merge: Firestore TTL-Policy auf `expiresAt` für Collection-Group `livelocation` aktivieren (dev + prod separat):

\`\`\`bash
gcloud firestore fields ttls update expiresAt --collection-group=livelocation --enable-ttl
\`\`\`

## Test plan

- [ ] Zwei Geräte / Browser im selben Firecall: A teilt → B sieht Marker mit Avatar + Name
- [ ] Bewegung von A spiegelt sich bei B nach Distanz- oder Heartbeat-Bedingung
- [ ] Stop bei A → Marker bei B verschwindet
- [ ] Firecall-Wechsel: Sharing stoppt, altes Doc gelöscht, localStorage-Eintrag bereinigt
- [ ] Tab-Refresh / Fast Refresh: Sharing läuft nahtlos weiter (Auto-Resume aus localStorage)
- [ ] Standort-Permission noch nicht erteilt: FAB-Click triggert Permission-Anfrage; bei Verweigerung kein Start
- [ ] Marker fadet ab 2 min Alter, verschwindet nach 5 min
- [ ] Eigener Marker nicht doppelt sichtbar (eigene UID rausgefiltert, eigener `PositionMarker` bleibt)
- [ ] Android: Foreground-Service-Notification zeigt Einsatz-Namen
- [ ] Android: Sharing läuft im Hintergrund weiter
- [ ] Android: Track-Recording + Live-Share parallel ohne Konflikt
- [ ] TTL Policy nach Deploy aktiviert (manuell, dev + prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)