### PR TITLE
fix(chrome-extension): build release artifact with prod DB and OAuth client

### DIFF
--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -25,6 +25,12 @@ jobs:
   build-and-upload:
     name: "Build and upload Chrome Extension"
     runs-on: ubuntu-latest
+    # Release events publish a prod artifact (CWS) and run on a `v*` tag ref, so
+    # they map to the `prod` environment (NEXT_PUBLIC_FIRESTORE_DB=default, prod
+    # CHROME_OAUTH_CLIENT_ID). Branch pushes / manual dispatch run on `main` and
+    # build a dev test artifact. The environment-level vars override the
+    # repo-level dev defaults.
+    environment: ${{ github.event_name == 'release' && 'prod' || 'main' }}
     permissions:
       id-token: write # required for Workload Identity Federation
       contents: read
@@ -158,9 +164,17 @@ jobs:
         run: |
           set -eo pipefail
           umask 077
+          # 'default' is the prod sentinel for the (default) Firestore database.
+          # The extension expects an empty string to fall back to
+          # getFirestore(app) (see chrome-extension/src/shared/config.ts).
+          DB="${NEXT_PUBLIC_FIRESTORE_DB}"
+          if [[ "${DB}" == "default" ]]; then
+            DB=""
+          fi
+          echo "Firestore DB: '${DB:-<default>}'  OAuth client: ${CHROME_OAUTH_CLIENT_ID%%-*}-…"
           cat > chrome-extension/.env.production.local <<EOF
           NEXT_PUBLIC_FIREBASE_APIKEY='${NEXT_PUBLIC_FIREBASE_APIKEY}'
-          NEXT_PUBLIC_FIRESTORE_DB='${NEXT_PUBLIC_FIRESTORE_DB}'
+          NEXT_PUBLIC_FIRESTORE_DB='${DB}'
           NEXT_PUBLIC_CHROME_OAUTH_CLIENT_ID='${CHROME_OAUTH_CLIENT_ID}'
           CHROME_EXTENSION_PUBLIC_KEY='${PUBLIC_KEY}'
           EOF

--- a/src/common/ai.ts
+++ b/src/common/ai.ts
@@ -2,4 +2,4 @@
  * Shared AI/Gemini configuration constants.
  * Update the model name here to change it for both client and server.
  */
-export const GEMINI_MODEL = 'gemini-3-flash-preview';
+export const GEMINI_MODEL = 'gemini-3.5-flash';


### PR DESCRIPTION
## Zusammenfassung

Der Chrome-Extension-Release-Workflow baute bisher immer gegen die **Dev-Umgebung** (`ffndev` + Dev-OAuth-Client-ID), auch beim Chrome-Web-Store-Release. Ursache: DB und Client-ID wurden direkt aus den Repository-Variablen (Dev-Defaults) gelesen, ohne bei einem Release auf Prod umzuschalten — anders als der Cloud-Run-Workflow, der das per Tag-Erkennung macht.

Zusätzlich wird das Gemini-Modell auf `gemini-3.5-flash` aktualisiert (getrennter Commit).

## Änderungen

- **Release-Workflow** wählt die GitHub-Environment per Event: `release: published` → `prod`, sonst `main`. Die `prod`-Environment (erlaubt Tag-Refs `v*`) liefert die Prod-DB und die Prod-OAuth-Client-ID; `push:main`/`workflow_dispatch` bleiben Dev-Testbuilds.
- DB-Sentinel `default` wird zu leerem String normalisiert, damit die Extension auf die `(default)`-Firestore-DB zurückfällt (analog zu `cloud-run.yml`, passend zu `chrome-extension/src/shared/config.ts`).
- Prod-OAuth-Client-ID als Variable `CHROME_OAUTH_CLIENT_ID` in der `prod`-Environment hinterlegt.
- `chore(ai)`: Gemini-Modell `gemini-3-flash-preview` → `gemini-3.5-flash` in `src/common/ai.ts`.

## Test plan

- [ ] `npm run check` läuft sauber durch (lokal: EXIT=0)
- [ ] Release-Build (`release: published`) baut gegen die Prod-DB (leerer `NEXT_PUBLIC_FIRESTORE_DB`) und nutzt die Prod-Client-ID
- [ ] Push auf `main` baut weiterhin einen Dev-Testbuild (Drive-Upload, `ffndev`)
- [ ] OAuth-Login mit der Prod-Client-ID für die veröffentlichte Extension-ID prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)