### PR TITLE
fix(android): Mikrofon-Berechtigung für AI-Assistent-Spracheingabe

### DIFF
--- a/capacitor/android/app/src/main/AndroidManifest.xml
+++ b/capacitor/android/app/src/main/AndroidManifest.xml
@@ -76,6 +76,12 @@
     <!-- Keep CPU awake while recording -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <!-- Microphone access for the AI assistant voice input (getUserMedia in the WebView).
+         Capacitor's BridgeWebChromeClient requests these at runtime before granting the
+         WebView's AUDIO_CAPTURE request; without them the request is auto-denied. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+
     <!-- Declare Bluetooth LE feature; make it optional so the app still installs on non-BLE devices -->
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 </manifest>


### PR DESCRIPTION
## Zusammenfassung

Die Spracheingabe des AI-Assistenten auf der Karte funktionierte im Android-Build nicht (in der Web-App problemlos). Ursache: Der WebView-Mikrofonzugriff via `getUserMedia({ audio: true })` wurde von Android automatisch abgelehnt, weil die nötigen Berechtigungen nicht im Manifest deklariert waren.

Capacitors `BridgeWebChromeClient.onPermissionRequest` fordert bei einer `AUDIO_CAPTURE`-Anfrage zur Laufzeit `RECORD_AUDIO` und `MODIFY_AUDIO_SETTINGS` an, bevor es die WebView-Anfrage gewährt. Sind diese nicht im Manifest deklariert, liefert der Permission-Launcher sofort *denied* zurück — ohne Dialog —, und `getUserMedia` schlägt fehl. In der Web-App tritt das nicht auf, weil der Browser die Mikrofon-Berechtigung selbst verwaltet.

## Änderungen

- `RECORD_AUDIO` und `MODIFY_AUDIO_SETTINGS` in `capacitor/android/app/src/main/AndroidManifest.xml` deklariert.

Damit zeigt Android beim ersten Mikrofon-Zugriff den Laufzeit-Dialog (`RECORD_AUDIO` ist *dangerous*); `MODIFY_AUDIO_SETTINGS` wird bereits bei der Installation gewährt. JS-seitig ist keine Anpassung nötig — Capacitor übernimmt Anforderung und WebView-Grant.

## Test plan

- [ ] `npx cap sync android` und Debug-Build (`JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :app:assembleDebug`)
- [ ] App installieren, AI-Assistent auf der Karte öffnen, Mikrofon antippen
- [ ] Beim ersten Antippen erscheint der Mikrofon-Berechtigungsdialog
- [ ] Nach Erteilung startet die Aufnahme und die Spracheingabe wird verarbeitet

🤖 Generated with [Claude Code](https://claude.com/claude-code)