### PR TITLE
fix(spectrum): Overflow-Bin ausblenden und eindeutige Serien-IDs

### DIFF
--- a/src/components/pages/EnergySpectrum.test.tsx
+++ b/src/components/pages/EnergySpectrum.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../hooks/useFirecallItemUpdate', () => ({
 }));
 
 vi.mock('../../hooks/useFirebaseCollection', () => ({
-  default: () => [],
+  default: vi.fn(() => []),
 }));
 
 vi.mock('../../hooks/useFirecall', () => ({
@@ -32,15 +32,29 @@ vi.mock('../providers/RadiacodeProvider', async () => {
   };
 });
 
-// Ersetzt den Chart durch ein stummes Div — JSDOM hat kein Canvas.
+// Captures the props passed to the (mocked) chart so tests can inspect the
+// series the page builds. JSDOM has no canvas, so the chart itself is stubbed.
+const chartMock = vi.hoisted(() => ({
+  lastProps: null as {
+    series?: { id?: string; label?: string }[];
+    energies?: number[];
+  } | null,
+}));
+
 vi.mock('./ZoomableSpectrumChart', () => ({
-  default: () => <div data-testid="zoomable-spectrum-chart" />,
+  default: (props: { series?: { id?: string; label?: string }[] }) => {
+    chartMock.lastProps = props;
+    return <div data-testid="zoomable-spectrum-chart" />;
+  },
 }));
 
 import { useRadiacode } from '../providers/RadiacodeProvider';
+import useFirebaseCollection from '../../hooks/useFirebaseCollection';
+import type { Spectrum } from '../firebase/firestore';
 import EnergySpectrum from './EnergySpectrum';
 
 const mockedUseRadiacode = vi.mocked(useRadiacode);
+const mockedUseFirebaseCollection = vi.mocked(useFirebaseCollection);
 
 function fixture(
   partial: Partial<RadiacodeContextValue> = {},
@@ -236,5 +250,54 @@ describe('EnergySpectrum — Live-Spektrum', () => {
     expect(
       screen.queryByRole('button', { name: /^speichern$/i }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('EnergySpectrum — Serien-IDs', () => {
+  function savedSpectrum(id: string, sampleName: string): Spectrum {
+    const counts = new Array<number>(300).fill(100);
+    return {
+      id,
+      type: 'spectrum',
+      name: sampleName,
+      sampleName,
+      deviceName: 'RC-103',
+      measurementTime: 100,
+      liveTime: 100,
+      startTime: '',
+      endTime: '',
+      coefficients: [0, 2.5, 0],
+      counts,
+    } as unknown as Spectrum;
+  }
+
+  beforeEach(() => {
+    mockedUseRadiacode.mockReturnValue(fixture());
+    mockedUseFirebaseCollection.mockReturnValue([] as never);
+    chartMock.lastProps = null;
+  });
+
+  it('nutzt eindeutige Firestore-IDs als Serien-ID, auch bei gleichem Titel', () => {
+    // Zwei Spektren mit identischem sampleName (Timestamp) — früher führte das
+    // zu doppelten React-Keys, weil der Titel als Key diente.
+    mockedUseFirebaseCollection.mockReturnValue([
+      savedSpectrum('a', '2026-04-19 20-15-08'),
+      savedSpectrum('b', '2026-04-19 20-15-08'),
+    ] as never);
+
+    render(<EnergySpectrum />);
+
+    const series = chartMock.lastProps?.series ?? [];
+    expect(series).toHaveLength(2);
+
+    const ids = series.map((s) => s.id);
+    expect(new Set(ids).size).toBe(2); // eindeutig trotz gleichem Titel
+    expect(ids).toEqual(['firestore-a', 'firestore-b']);
+
+    // Der kollidierende Titel bleibt das Label, dient aber nicht als ID.
+    expect(series.map((s) => s.label)).toEqual([
+      '2026-04-19 20-15-08',
+      '2026-04-19 20-15-08',
+    ]);
   });
 });

--- a/src/components/pages/EnergySpectrum.tsx
+++ b/src/components/pages/EnergySpectrum.tsx
@@ -66,6 +66,7 @@ import useFirebaseCollection from '../../hooks/useFirebaseCollection';
 import { useRadiacode } from '../providers/RadiacodeProvider';
 import { useSnackbar } from '../providers/SnackbarProvider';
 import RadiacodeConnectionControls from './RadiacodeConnectionControls';
+import { getDisplayRange } from './spectrumDisplay';
 import ZoomableSpectrumChart from './ZoomableSpectrumChart';
 
 /** MUI default color palette for series */
@@ -118,23 +119,6 @@ interface LoadedSpectrum {
   visible: boolean;
   description?: string;
   manualNuclide?: string;
-}
-
-/**
- * Trim trailing zero-count channels.
- * Returns the last meaningful index across all spectra + padding.
- */
-function getDisplayRange(spectra: LoadedSpectrum[]): number {
-  let maxIndex = 0;
-  for (const s of spectra) {
-    for (let i = s.data.counts.length - 1; i >= 0; i--) {
-      if (s.data.counts[i] > 0) {
-        maxIndex = Math.max(maxIndex, i);
-        break;
-      }
-    }
-  }
-  return Math.min(maxIndex + 20, 1024);
 }
 
 /** Nuclides that have peak energies defined for matching. */
@@ -417,7 +401,7 @@ export default function EnergySpectrum() {
   const displayRange = useMemo(
     () =>
       deferredVisibleSpectra.length > 0
-        ? getDisplayRange(deferredVisibleSpectra)
+        ? getDisplayRange(deferredVisibleSpectra.map((s) => s.data.counts))
         : 0,
     [deferredVisibleSpectra],
   );
@@ -500,6 +484,7 @@ export default function EnergySpectrum() {
       const padded = s.data.counts.slice(0, displayRange);
       while (padded.length < displayRange) padded.push(0);
       return {
+        id: s.id,
         data: padded,
         label: s.data.sampleName || `Spektrum ${originalIdx + 1}`,
         color: colorForSpectrum(s, firestoreIdx),

--- a/src/components/pages/SpectrumChart.tsx
+++ b/src/components/pages/SpectrumChart.tsx
@@ -10,6 +10,7 @@ import {
   type NuclideMatch,
 } from '../../common/spectrumParser';
 import { type Spectrum } from '../firebase/firestore';
+import { getDisplayRange } from './spectrumDisplay';
 import ZoomableSpectrumChart from './ZoomableSpectrumChart';
 
 const SERIES_COLORS = [
@@ -22,25 +23,10 @@ const SERIES_COLORS = [
 ];
 
 interface LoadedSpectrum {
+  /** Stable unique id (Firestore document id) — used as series id / React key. */
+  id: string;
   data: SpectrumData;
   matches: NuclideMatch[];
-}
-
-/**
- * Trim trailing zero-count channels.
- * Returns the last meaningful index across all spectra + padding.
- */
-function getDisplayRange(data: { counts: number[] }[]): number {
-  let maxIndex = 0;
-  for (const s of data) {
-    for (let i = s.counts.length - 1; i >= 0; i--) {
-      if (s.counts[i] > 0) {
-        maxIndex = Math.max(maxIndex, i);
-        break;
-      }
-    }
-  }
-  return Math.min(maxIndex + 20, 1024);
 }
 
 export interface SpectrumChartProps {
@@ -55,7 +41,7 @@ export default function SpectrumChart({
   const loadedSpectra = useMemo<LoadedSpectrum[]>(() => {
     return spectra
       .filter((s) => s.counts?.length > 0)
-      .map((saved) => {
+      .map((saved, idx) => {
         const energies = saved.counts.map((_, ch) =>
           channelToEnergy(ch, saved.coefficients)
         );
@@ -72,12 +58,15 @@ export default function SpectrumChart({
         };
         const peaks = findPeaks(dataWithEnergies.counts, energies);
         const matches = identifyNuclides(peaks);
-        return { data: dataWithEnergies, matches };
+        return { id: saved.id ?? `spectrum-${idx}`, data: dataWithEnergies, matches };
       });
   }, [spectra]);
 
   const displayRange = useMemo(
-    () => (loadedSpectra.length > 0 ? getDisplayRange(loadedSpectra.map((s) => s.data)) : 0),
+    () =>
+      loadedSpectra.length > 0
+        ? getDisplayRange(loadedSpectra.map((s) => s.data.counts))
+        : 0,
     [loadedSpectra]
   );
 
@@ -106,6 +95,7 @@ export default function SpectrumChart({
       const padded = s.data.counts.slice(0, displayRange);
       while (padded.length < displayRange) padded.push(0);
       return {
+        id: s.id,
         data: padded,
         label: s.data.sampleName || `Spektrum ${idx + 1}`,
         color: SERIES_COLORS[idx % SERIES_COLORS.length],

--- a/src/components/pages/ZoomableSpectrumChart.tsx
+++ b/src/components/pages/ZoomableSpectrumChart.tsx
@@ -22,6 +22,7 @@ import {
   type NuclideAtEnergy,
 } from '../../common/nuclidesAtEnergy';
 import { channelToEnergy } from '../../common/spectrumParser';
+import { dropOverflowBin } from './spectrumDisplay';
 import {
   applyPan,
   applyWheelZoom,
@@ -45,6 +46,12 @@ export interface ZoomableSpectrumChartProps {
   energies?: number[];
   /** Multi-spectrum input: caller-supplied series (same length as energies). */
   series?: {
+    /**
+     * Stable, unique series id (e.g. the Firestore document id). Used as the
+     * MUI series id and as React keys — must not be the sample name/title,
+     * which can collide between spectra recorded at the same timestamp.
+     */
+    id?: string;
     data: number[];
     label?: string;
     color?: string;
@@ -162,27 +169,36 @@ export default function ZoomableSpectrumChart({
   overlays,
   onPointerMove,
 }: ZoomableSpectrumChartProps) {
+  // Channel counts with the trailing overflow bin removed (the last channel on
+  // RadiaCode devices collects all over-range events as one huge spike — not a
+  // real measurement, so it is kept out of the displayed data). The multi-
+  // series (`series`/`energies`) path is already trimmed by its caller.
+  const displayCounts = useMemo(
+    () => (counts && counts.length > 0 ? dropOverflowBin(counts) : counts),
+    [counts],
+  );
+
   // Compute X-axis energies once per input change.
   const xEnergies = useMemo<number[] | null>(() => {
     if (energiesProp && energiesProp.length > 0) return energiesProp;
-    if (counts && counts.length > 0 && coefficients) {
-      return counts.map((_, ch) => channelToEnergy(ch, coefficients));
+    if (displayCounts && displayCounts.length > 0 && coefficients) {
+      return displayCounts.map((_, ch) => channelToEnergy(ch, coefficients));
     }
     return null;
-  }, [energiesProp, counts, coefficients]);
+  }, [energiesProp, displayCounts, coefficients]);
 
   // Compute series once per input change.
   const chartSeries = useMemo(() => {
     if (seriesProp && seriesProp.length > 0) return seriesProp;
-    if (counts && counts.length > 0) {
-      return [{ data: counts, showMark: false } as const];
+    if (displayCounts && displayCounts.length > 0) {
+      return [{ data: displayCounts, showMark: false } as const];
     }
     return null;
-  }, [seriesProp, counts]);
+  }, [seriesProp, displayCounts]);
 
   const defaultXRange = useMemo<Range>(
-    () => computeDefaultXRange(counts, coefficients, xEnergies ?? undefined),
-    [counts, coefficients, xEnergies],
+    () => computeDefaultXRange(displayCounts, coefficients, xEnergies ?? undefined),
+    [displayCounts, coefficients, xEnergies],
   );
 
   const [xRange, setXRange] = useState<Range>(defaultXRange);
@@ -461,6 +477,7 @@ export default function ZoomableSpectrumChart({
   // index to pick a bin from each series' `data` array.
   const hoverSeriesValues = useMemo<
     {
+      key: string;
       label: string;
       color?: string;
       counts: number;
@@ -481,6 +498,7 @@ export default function ZoomableSpectrumChart({
     }
     return chartSeries.map((s, i) => {
       const anyS = s as {
+        id?: string;
         data: number[];
         label?: string;
         color?: string;
@@ -489,6 +507,9 @@ export default function ZoomableSpectrumChart({
       const counts = anyS.data[idx] ?? 0;
       const live = typeof anyS.liveTime === 'number' ? anyS.liveTime : null;
       return {
+        // Prefer the stable series id; fall back to the index so the React key
+        // stays unique even when two series share a label (sample name).
+        key: anyS.id ?? `series-${i}`,
         label: anyS.label ?? `Serie ${i + 1}`,
         color: anyS.color,
         counts,
@@ -674,7 +695,7 @@ export default function ZoomableSpectrumChart({
               >
                 {hoverSeriesValues.map((v) => (
                   <Typography
-                    key={v.label}
+                    key={v.key}
                     variant="caption"
                     sx={{
                       display: 'flex',

--- a/src/components/pages/spectrumDisplay.test.ts
+++ b/src/components/pages/spectrumDisplay.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { dropOverflowBin, getDisplayRange } from './spectrumDisplay';
+
+/** Build a 1024-channel spectrum: real counts up to `lastReal`, then a huge
+ *  spike in the final (overflow) channel. */
+function spectrumWithOverflow(lastReal: number, length = 1024): number[] {
+  const counts = new Array<number>(length).fill(0);
+  for (let i = 0; i <= lastReal; i++) counts[i] = 100;
+  counts[length - 1] = 50250; // overflow bin
+  return counts;
+}
+
+describe('dropOverflowBin', () => {
+  it('drops the trailing overflow bin', () => {
+    expect(dropOverflowBin([1, 2, 3])).toEqual([1, 2]);
+  });
+
+  it('leaves arrays of length <= 1 unchanged', () => {
+    expect(dropOverflowBin([5])).toEqual([5]);
+    expect(dropOverflowBin([])).toEqual([]);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [1, 2, 3];
+    dropOverflowBin(input);
+    expect(input).toEqual([1, 2, 3]);
+  });
+});
+
+describe('getDisplayRange', () => {
+  it('returns 0 for empty input', () => {
+    expect(getDisplayRange([])).toBe(0);
+  });
+
+  it('ignores the overflow bin when real data ends well before it', () => {
+    // Real data to channel 50, spike at 1023 → 50 + 20 padding = 70.
+    expect(getDisplayRange([spectrumWithOverflow(50)])).toBe(70);
+  });
+
+  it('never re-includes the overflow bin even when padding reaches the end', () => {
+    // Real data to channel 1010 → 1010 + 20 = 1030, clamped to 1023 so
+    // Array.slice(0, 1023) excludes the overflow bin at index 1023.
+    expect(getDisplayRange([spectrumWithOverflow(1010)])).toBe(1023);
+  });
+
+  it('falls back to padding only when nothing but the overflow bin is set', () => {
+    const counts = new Array<number>(1024).fill(0);
+    counts[1023] = 50250;
+    expect(getDisplayRange([counts])).toBe(20);
+  });
+
+  it('uses the maximum extent across multiple spectra', () => {
+    expect(
+      getDisplayRange([spectrumWithOverflow(40), spectrumWithOverflow(120)]),
+    ).toBe(140);
+  });
+
+  it('respects a custom padding', () => {
+    expect(getDisplayRange([spectrumWithOverflow(50)], 5)).toBe(55);
+  });
+});

--- a/src/components/pages/spectrumDisplay.ts
+++ b/src/components/pages/spectrumDisplay.ts
@@ -1,0 +1,44 @@
+/**
+ * Display helpers for gamma spectra.
+ *
+ * RadiaCode devices accumulate every event above the calibrated energy range
+ * in the final channel (the "overflow bin"). It carries no spectroscopic
+ * information and shows up as a single huge spike at the very right edge of
+ * the spectrum. These helpers keep that channel out of the *displayed* data
+ * (the raw/stored counts are left untouched).
+ */
+
+/**
+ * Return an aligned channel array without its trailing overflow bin.
+ * Arrays of length ≤ 1 are returned unchanged (nothing safe to drop).
+ */
+export function dropOverflowBin<T>(arr: T[]): T[] {
+  return arr.length > 1 ? arr.slice(0, -1) : arr;
+}
+
+/**
+ * Exclusive upper bound (≈ display length) across one or more spectra: the
+ * highest channel with counts > 0 plus `padding`, ignoring the overflow bin in
+ * the last channel. Suitable for `Array.slice(0, n)` and as an energy-axis
+ * length. Returns 0 for empty input.
+ */
+export function getDisplayRange(
+  countsArrays: number[][],
+  padding = 20,
+): number {
+  let maxIndex = 0;
+  let maxLen = 0;
+  for (const counts of countsArrays) {
+    maxLen = Math.max(maxLen, counts.length);
+    // Start at length-2 so the overflow bin (last channel) never sets the
+    // range, even when it is the only non-zero channel near the end.
+    for (let i = counts.length - 2; i >= 0; i--) {
+      if (counts[i] > 0) {
+        maxIndex = Math.max(maxIndex, i);
+        break;
+      }
+    }
+  }
+  // Clamp to maxLen-1 so the padding can never re-include the overflow bin.
+  return Math.min(maxIndex + padding, Math.max(maxLen - 1, 0));
+}


### PR DESCRIPTION
## Zusammenfassung

Behebt zwei Fehler in der Spektrum-Anzeige (RadiaCode):

1. **Overflow-Bin als hoher Peak am rechten Rand.** Der letzte Kanal sammelt bei RadiaCode-Geräten alle Ereignisse oberhalb des kalibrierten Energiebereichs und erscheint als einzelner, sehr hoher Peak ganz rechts im Spektrum. Er trägt keine spektroskopische Information.
2. **Doppelte React-Keys** (`Encountered two children with the same key, 2026-04-19 20-15-08`): Zwei Spektren mit identischem `sampleName` (Timestamp) kollidierten, weil der Titel als Key/ID diente.

Beide Fixes betreffen ausschließlich die Anzeige — die in Firestore gespeicherten Rohdaten bleiben unverändert.

## Änderungen

- Neuer, getesteter Helper `spectrumDisplay.ts` mit `dropOverflowBin` und `getDisplayRange`, der den Overflow-Bin (letzten Kanal) aus der Darstellung nimmt.
- Eingebunden in alle drei Anzeige-Pfade: `SpectrumChart`, `EnergySpectrum` (Mehr-Spektren) und `ZoomableSpectrumChart` (`counts`-Pfad: Live-Widget, FirecallSpectrum, Dosimetrie). Wirkt auf Anzeige-Bereich, Daten und Y-Achsen-Skalierung.
- Spektren-Serien tragen jetzt eine stabile, eindeutige `id` aus Firestore (`firestore-…` bzw. `live`) statt des Titels — verwendet als MUI-Series-`id` und als React-Key im Hover-Popup.
- Regressionstest: zwei Spektren mit gleichem Titel erhalten eindeutige Serien-IDs (`firestore-a`/`firestore-b`); der Titel bleibt nur Label.

## Test plan

- [x] `npx tsc --noEmit` ohne Fehler
- [x] `npx eslint` ohne Warnungen
- [x] `npx vitest run` — 1162 Tests grün (inkl. neuer Tests `spectrumDisplay.test.ts` und Serien-ID-Regressionstest)
- [x] `npx next build --webpack` erfolgreich
- [ ] Manuell: Cs-137-Spektrum laden → kein Peak mehr am rechten Rand
- [ ] Manuell: zwei Spektren mit gleichem Titel sichtbar → keine React-Key-Warnung in der Konsole

🤖 Generated with [Claude Code](https://claude.com/claude-code)