### PR TITLE
fix(chrome-extension): normalize Firestore default-DB sentinel

### DIFF
--- a/.github/workflows/chrome-extension-release.yml
+++ b/.github/workflows/chrome-extension-release.yml
@@ -26,10 +26,11 @@ jobs:
     name: "Build and upload Chrome Extension"
     runs-on: ubuntu-latest
     # Release events publish a prod artifact (CWS) and run on a `v*` tag ref, so
-    # they map to the `prod` environment (NEXT_PUBLIC_FIRESTORE_DB=default, prod
-    # CHROME_OAUTH_CLIENT_ID). Branch pushes / manual dispatch run on `main` and
-    # build a dev test artifact. The environment-level vars override the
-    # repo-level dev defaults.
+    # they map to the `prod` environment (NEXT_PUBLIC_FIRESTORE_DB=(default),
+    # prod CHROME_OAUTH_CLIENT_ID). Branch pushes / manual dispatch run on `main`
+    # and build a dev test artifact. The environment-level vars override the
+    # repo-level dev defaults. The `(default)` sentinel is normalised to an
+    # empty string below (GitHub forbids empty variable values).
     environment: ${{ github.event_name == 'release' && 'prod' || 'main' }}
     permissions:
       id-token: write # required for Workload Identity Federation
@@ -164,13 +165,21 @@ jobs:
         run: |
           set -eo pipefail
           umask 077
-          # 'default' is the prod sentinel for the (default) Firestore database.
-          # The extension expects an empty string to fall back to
-          # getFirestore(app) (see chrome-extension/src/shared/config.ts).
+          # '(default)' (and the legacy 'default') is the prod sentinel for the
+          # (default) Firestore database. The extension expects an empty string
+          # to fall back to getFirestore(app) (see
+          # chrome-extension/src/shared/config.ts).
           DB="${NEXT_PUBLIC_FIRESTORE_DB}"
-          if [[ "${DB}" == "default" ]]; then
+          if [[ "${DB}" == "default" || "${DB}" == "(default)" ]]; then
             DB=""
           fi
+          # Re-export the sanitised value so the later "Build extension" step
+          # sees the clean value in process.env. Vite resolves
+          # import.meta.env from envDir=ROOT_DIR (no .env file in CI) and falls
+          # back to process.env, so the raw sentinel from the job-level env would
+          # otherwise be baked into the bundle, breaking Firestore with
+          # "Database '(default)' not found". Mirrors cloud-run.yml for the web app.
+          echo "NEXT_PUBLIC_FIRESTORE_DB=${DB}" >> "$GITHUB_ENV"
           echo "Firestore DB: '${DB:-<default>}'  OAuth client: ${CHROME_OAUTH_CLIENT_ID%%-*}-…"
           cat > chrome-extension/.env.production.local <<EOF
           NEXT_PUBLIC_FIREBASE_APIKEY='${NEXT_PUBLIC_FIREBASE_APIKEY}'

--- a/.github/workflows/cloud-run.yml
+++ b/.github/workflows/cloud-run.yml
@@ -73,8 +73,8 @@ jobs:
             export SUMUP_SECRET_SUFFIX=""
           fi
 
-          if [[ "${NEXT_PUBLIC_FIRESTORE_DB}" == "default" ]]; then
-            # set to empty string
+          if [[ "${NEXT_PUBLIC_FIRESTORE_DB}" == "default" || "${NEXT_PUBLIC_FIRESTORE_DB}" == "(default)" ]]; then
+            # '(default)' / 'default' sentinel -> empty string selects the default DB
             export NEXT_PUBLIC_FIRESTORE_DB=""
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,40 @@ Call the guard at the top of every server action before any logic. For API route
 - `layer` - Map layers per firecall
 - `user` - User profiles with authorization
 - `clusters6` - Geohashed hydrant clusters
+- `bugReport` - In-App Bug-Reports & Feature-Requests (siehe unten)
+- `appConfig` - App-weite Konfiguration (u.a. Dokument `bugReport` mit Empfänger-E-Mails)
+
+## Bug Reports / Feedback
+
+In-App-Bug-Reports und Feature-Requests werden über den Bug-Report-Dialog
+([src/components/bugReport/](src/components/bugReport/)) in die Firestore-Collection
+`bugReport` geschrieben. Der TypeScript-Typ liegt in [src/common/bugReport.ts](src/common/bugReport.ts)
+(`BugReport`: u.a. `kind` `'bug' | 'feature'`, `title`, `description`,
+`status` `'open' | 'in_progress' | 'closed' | 'wontfix'`, `createdAt`, `createdBy`,
+`context` mit `url`/`buildId`/`database`/`platform`/`firecallId`, `logs`, `screenshots`).
+
+**Wichtig:** Produktive Bug-Reports liegen in der **Default-Datenbank `(default)`** des
+Projekts `ffn-utils` — NICHT in `ffndev`. Das Feld `context.database` zeigt, aus welcher
+Umgebung der Report stammt (`""` = prod, `ffndev` = dev).
+
+**Reports abrufen (Firebase MCP, neueste zuerst):**
+
+```jsonc
+// Tool: firestore_query_collection
+{
+  "collection_path": "bugReport",
+  "database": "(default)",            // prod; für Dev: "ffndev"
+  "filters": [],                       // optional, z.B. status == "open"
+  "order": { "orderBy": "createdAt", "orderByDirection": "DESCENDING" },
+  "limit": 15
+}
+```
+
+Nur offene Reports: `filters: [{ field: "status", op: "EQUAL", compare_value: { string_value: "open" } }]`.
+
+Alternativ im Admin-Panel unter `/admin/bug-reports`
+([src/app/admin/bug-reports/](src/app/admin/bug-reports/)), wo sich auch Status und
+Empfänger-E-Mails (`appConfig/bugReport`) pflegen lassen.
 
 ## German Terminology
 

--- a/chrome-extension/src/shared/config.test.ts
+++ b/chrome-extension/src/shared/config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeFirestoreDb } from './config';
+
+describe('normalizeFirestoreDb', () => {
+  it('treats an empty / missing value as the default database', () => {
+    expect(normalizeFirestoreDb('')).toBe('');
+    expect(normalizeFirestoreDb(undefined)).toBe('');
+  });
+
+  it("treats the prod sentinel 'default' as the default database", () => {
+    // The prod GitHub environment sets NEXT_PUBLIC_FIRESTORE_DB=default as a
+    // sentinel. The Firebase SDK addresses the default database via
+    // getFirestore(app) WITHOUT a database id — passing the literal string
+    // 'default' raises "Database 'default' not found".
+    expect(normalizeFirestoreDb('default')).toBe('');
+  });
+
+  it("treats the canonical '(default)' id as the default database", () => {
+    expect(normalizeFirestoreDb('(default)')).toBe('');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeFirestoreDb('  default  ')).toBe('');
+    expect(normalizeFirestoreDb('  ffndev  ')).toBe('ffndev');
+  });
+
+  it('keeps a real named database id untouched', () => {
+    expect(normalizeFirestoreDb('ffndev')).toBe('ffndev');
+  });
+});

--- a/chrome-extension/src/shared/config.ts
+++ b/chrome-extension/src/shared/config.ts
@@ -4,8 +4,21 @@ export const FIREBASE_CONFIG = JSON.parse(
   import.meta.env.NEXT_PUBLIC_FIREBASE_APIKEY || '{}'
 );
 
+// Normalises the configured Firestore database id. The default database must
+// be addressed via getFirestore(app) WITHOUT an id — passing the literal
+// strings 'default' (the prod GitHub-environment sentinel) or '(default)'
+// raises "Database 'default' not found". An empty result selects the default.
+export function normalizeFirestoreDb(raw: string | undefined): string {
+  const value = (raw ?? '').trim();
+  if (value === '' || value === 'default' || value === '(default)') {
+    return '';
+  }
+  return value;
+}
+
 // 'ffndev' for dev, empty string for prod
-export const FIRESTORE_DB: string =
-  import.meta.env.NEXT_PUBLIC_FIRESTORE_DB || '';
+export const FIRESTORE_DB: string = normalizeFirestoreDb(
+  import.meta.env.NEXT_PUBLIC_FIRESTORE_DB
+);
 
 export const EINSATZKARTE_URL = 'https://einsatz.ffnd.at';


### PR DESCRIPTION
## Zusammenfassung

Behebt den Bug-Report „Chrome Extension lädt falsche DB" (Firestore: `Database 'default' not found`).

Die prod-GitHub-Environment-Variable `NEXT_PUBLIC_FIRESTORE_DB` ist ein Sentinel für die Firestore-Default-Datenbank. Beim Release-Build der Extension sickerte der rohe Wert über `process.env` in den Vite-Build: Vite löst `import.meta.env` über `envDir=ROOT_DIR` auf, wo im CI-Checkout keine `.env`-Datei liegt, und fällt auf `process.env` zurück. Dadurch wurde der Sentinel ins Bundle gebacken, die Extension rief `getFirestore(app, "default")` auf und scheiterte. Fix #564 hatte nur den Datei-Inhalt (`.env.production.local`) sanitiert, nicht `process.env`. Die Web-App war nicht betroffen, weil `cloud-run.yml` den Wert nach `$GITHUB_ENV` re-exportiert.

Zusätzlich wurde die prod-Variable von `default` auf `(default)` (kanonische Default-DB-ID) umgestellt — GitHub erlaubt keine leeren Variablenwerte.

## Änderungen

- **`config.ts`**: neue `normalizeFirestoreDb()` wandelt `''`, `'default'` und `'(default)'` in `''` um → `getFirestore(app)` (Default-DB). Bulletproof, unabhängig vom Injektionsweg. Mit Unit-Tests (TDD).
- **`chrome-extension-release.yml`**: sanitierten DB-Wert nach `$GITHUB_ENV` exportieren, damit der Build-Step `process.env` sauber sieht (konsistent zur Web-Pipeline); Sentinel behandelt nun auch `(default)`.
- **`cloud-run.yml`**: Sentinel behandelt zusätzlich `(default)`.
- **`CLAUDE.md`**: Abschnitt „Bug Reports / Feedback" — wie aktuelle Reports aus Firestore (`bugReport`, prod-DB `(default)`) abgerufen werden.
- **Infra**: prod-Environment-Variable `NEXT_PUBLIC_FIRESTORE_DB` auf `(default)` gesetzt.

## Test plan

- [x] `npx tsc --noEmit` (chrome-extension) — fehlerfrei
- [x] `npx eslint` — fehlerfrei
- [x] `npx vitest run` — 99 Tests grün (inkl. 5 neue `normalizeFirestoreDb`-Cases)
- [x] Prod-Build mit simuliertem Leck (`NEXT_PUBLIC_FIRESTORE_DB=(default)`): Bundle bäckt keine DB-ID ein → `getFirestore(app)`
- [ ] Nach Merge: neues Extension-Release publizieren, damit der Fix bei den Nutzern ankommt

🤖 Generated with [Claude Code](https://claude.com/claude-code)