### PR TITLE
feat: add adresse field to hydrants

### DIFF
--- a/src/common/gis-objects.ts
+++ b/src/common/gis-objects.ts
@@ -24,6 +24,7 @@ export const GEOHASH_PRECISION = 6;
 // Name,ortschaft,Typ,Hydranten Nummer,Fuellhydrant,Dimension,Leitungsart,Statischer Druck,Dynamischer Druck,DRUCKMESSUNG_DATUM,Meereshoehe,c_x,c_y,
 export interface Hydrant {
   ortschaft: string;
+  adresse?: string;
   typ: string;
   hydranten_nummer: string;
   fuellhydrant: string;

--- a/src/components/Einsatzorte/LocationMapPicker.tsx
+++ b/src/components/Einsatzorte/LocationMapPicker.tsx
@@ -50,6 +50,11 @@ interface LocationMapPickerProps {
   showFirecallLayers?: boolean;
   /** Custom dialog title. Default: "Position auf Karte wählen" */
   title?: string;
+  /**
+   * Pre-fills the search field when the dialog opens. If no initial position
+   * (lat/lng) is set, the query is geocoded automatically on open.
+   */
+  initialSearchQuery?: string;
 }
 
 function ClickHandler({
@@ -86,6 +91,7 @@ export default function LocationMapPicker({
   center = { lat: 47.9485, lng: 16.8452 }, // Neusiedl am See default
   showFirecallLayers = true,
   title = 'Position auf Karte wählen',
+  initialSearchQuery,
 }: LocationMapPickerProps) {
   const [position, setPosition] = useState<{ lat: number; lng: number } | null>(
     initialLat && initialLng ? { lat: initialLat, lng: initialLng } : null
@@ -93,17 +99,6 @@ export default function LocationMapPicker({
   const [searchQuery, setSearchQuery] = useState('');
   const [searching, setSearching] = useState(false);
   const [flyTarget, setFlyTarget] = useState<{ lat: number; lng: number } | null>(null);
-
-  // Reset state when the dialog opens
-  useEffect(() => {
-    if (open) {
-      const initial =
-        initialLat && initialLng ? { lat: initialLat, lng: initialLng } : null;
-      setPosition(initial);
-      setFlyTarget(initial);
-      setSearchQuery('');
-    }
-  }, [open, initialLat, initialLng]);
 
   const handleClick = useCallback((lat: number, lng: number) => {
     setPosition({ lat, lng });
@@ -116,8 +111,8 @@ export default function LocationMapPicker({
     onClose();
   }, [position, onConfirm, onClose]);
 
-  const handleSearch = useCallback(async () => {
-    const q = searchQuery.trim();
+  const geocode = useCallback(async (query: string) => {
+    const q = query.trim();
     if (!q) return;
     setSearching(true);
     try {
@@ -136,13 +131,34 @@ export default function LocationMapPicker({
         const lat = parseFloat(data[0].lat);
         const lng = parseFloat(data[0].lon);
         setFlyTarget({ lat, lng });
+        setPosition({ lat, lng });
       }
     } catch (err) {
       console.error('Geocoding failed:', err);
     } finally {
       setSearching(false);
     }
-  }, [searchQuery]);
+  }, []);
+
+  const handleSearch = useCallback(() => {
+    geocode(searchQuery);
+  }, [geocode, searchQuery]);
+
+  // Reset state when the dialog opens
+  useEffect(() => {
+    if (open) {
+      const initial =
+        initialLat && initialLng ? { lat: initialLat, lng: initialLng } : null;
+      setPosition(initial);
+      setFlyTarget(initial);
+      const query = initialSearchQuery ?? '';
+      setSearchQuery(query);
+      // No position yet but an address to search → geocode automatically
+      if (!initial && query.trim()) {
+        geocode(query);
+      }
+    }
+  }, [open, initialLat, initialLng, initialSearchQuery, geocode]);
 
   const mapCenter = position || center;
 

--- a/src/components/FirecallItems/elements/FirecallHydrant.tsx
+++ b/src/components/FirecallItems/elements/FirecallHydrant.tsx
@@ -7,6 +7,7 @@ import { FirecallItemBase } from './FirecallItemBase';
 
 export class FirecallHydrant extends FirecallItemBase {
   ortschaft: string;
+  adresse: string;
   typ: string;
   hydranten_nummer: string;
   fuellhydrant: string;
@@ -25,6 +26,7 @@ export class FirecallHydrant extends FirecallItemBase {
     this.editable = true;
     ({
       ortschaft: this.ortschaft = '',
+      adresse: this.adresse = '',
       typ: this.typ = 'Überflurhydrant',
       hydranten_nummer: this.hydranten_nummer = '',
       fuellhydrant: this.fuellhydrant = '',
@@ -47,6 +49,7 @@ export class FirecallHydrant extends FirecallItemBase {
     return {
       ...super.data(),
       ortschaft: this.ortschaft,
+      adresse: this.adresse,
       typ: this.typ,
       hydranten_nummer: this.hydranten_nummer,
       fuellhydrant: this.fuellhydrant,
@@ -65,6 +68,7 @@ export class FirecallHydrant extends FirecallItemBase {
     return {
       name: 'Name',
       ortschaft: 'Ortschaft',
+      adresse: 'Adresse',
       typ: 'Typ',
       hydranten_nummer: 'Hydrantennummer',
       fuellhydrant: 'Füllhydrant',
@@ -119,6 +123,12 @@ export class FirecallHydrant extends FirecallItemBase {
           <br />
           {this.leistung ? this.leistung + ' l/min ' : ''} ({this.dimension}mm)
         </b>
+        {this.adresse && (
+          <>
+            <br />
+            {this.adresse}
+          </>
+        )}
         <br />
         dynamisch: {this.dynamischer_druck} bar
         <br />

--- a/src/components/Map/markers/HydrantMarker.tsx
+++ b/src/components/Map/markers/HydrantMarker.tsx
@@ -69,6 +69,12 @@ export default function HydrantMarker({
           {hydrant.leistung ? hydrant.leistung + ' l/min ' : ''} (
           {hydrant.dimension}mm)
         </b>
+        {hydrant.adresse && (
+          <>
+            <br />
+            {hydrant.adresse}
+          </>
+        )}
         <br />
         dynamisch: {hydrant.dynamischer_druck} bar
         <br />

--- a/src/components/admin/ClusterItemEditDialog.tsx
+++ b/src/components/admin/ClusterItemEditDialog.tsx
@@ -171,6 +171,10 @@ export default function ClusterItemEditDialog({
             ? parseFloat(formData.lng)
             : undefined
         }
+        initialSearchQuery={[formData.adresse, formData.ortschaft]
+          .map((s) => s?.trim())
+          .filter(Boolean)
+          .join(', ')}
       />
     </>
   );

--- a/src/components/admin/clusterItemConfig.ts
+++ b/src/components/admin/clusterItemConfig.ts
@@ -34,6 +34,7 @@ export const collectionConfigs: CollectionConfig[] = [
     fields: [
       { key: 'name', label: 'Name', type: 'text', required: true, tableColumn: true },
       { key: 'ortschaft', label: 'Ortschaft', type: 'text', tableColumn: true },
+      { key: 'adresse', label: 'Adresse', type: 'text', tableColumn: true },
       { key: 'typ', label: 'Typ', type: 'text', tableColumn: true },
       { key: 'hydranten_nummer', label: 'Hydranten Nr.', type: 'text', tableColumn: true },
       { key: 'fuellhydrant', label: 'Füllhydrant', type: 'text' },


### PR DESCRIPTION
## Zusammenfassung

Zwei zusammenhängende Verbesserungen für Hydranten in der Admin-/Karten-UI:

1. **Adress-Feld für Hydranten** — Hydranten (aus `clusters6`) erhalten ein optionales Adressfeld, konsistent zu Risiko-/Gefahrobjekten, Löschteichen und Saugstellen.
2. **Auto-Geocoding im Karten-Picker** — Beim Öffnen der Karte im Admin-Cluster-Dialog wird das Suchfeld automatisch aus Adresse + Ortschaft befüllt. Ist keine Position gesetzt, wird die Adresse direkt geokodiert und als Marker gesetzt.

## Änderungen

### Adress-Feld
- **Typ** (`src/common/gis-objects.ts`): `adresse?: string` zum `Hydrant`-Interface (optional, Bestandsdaten haben es nicht).
- **Admin-Cluster-Dialog** (`clusterItemConfig.ts`): `adresse` als Textfeld + Tabellenspalte nach `ortschaft`.
- **Karten-Sidebar** (`FirecallHydrant.tsx`): `adresse` als Property, im Constructor, in `data()` und `fields()` ergänzt — editierbar via `FirecallItemFields`.
- **Popup-Anzeige**: Adresse (falls gesetzt) im Marker-Popup (`HydrantMarker.tsx`) und in `FirecallHydrant.popupFn()`.

### Auto-Geocoding
- **`LocationMapPicker.tsx`**: neuer optionaler Prop `initialSearchQuery`. Das Suchfeld wird beim Öffnen damit vorbefüllt. Die Geocoding-Logik wurde in einen `geocode(query)`-Helper ausgelagert, der jetzt **Marker + Karten-Zentrierung** setzt (gilt auch für manuelle Suche). Ohne vorhandene Position wird die Adresse beim Öffnen automatisch geokodiert.
- **`ClusterItemEditDialog.tsx`**: übergibt `initialSearchQuery` aus `adresse` + `ortschaft`.

Bewusst nicht enthalten (YAGNI): keine Datenmigration, keine Pflichtfeld-Validierung, kein Wechsel des Geocoding-Dienstes (weiter Nominatim wie bisher im Picker).

## Test plan

- [x] `tsc --noEmit` ohne Fehler
- [x] `eslint` ohne Warnungen
- [x] `vitest run` — alle Tests grün (1187 passed)
- [x] `next build --webpack` erfolgreich
- [ ] Manuell: Hydrant im `/admin`-Cluster-Dialog mit Adresse + Ortschaft, ohne lat/lng anlegen → Karte öffnen → Suchfeld vorbefüllt, Marker automatisch auf geokodierter Adresse, "Übernehmen" aktiv
- [ ] Manuell: vorhandene lat/lng → Karte öffnet auf Position, Suchfeld trotzdem vorbefüllt, kein Auto-Sprung
- [ ] Manuell: Adresse in Karten-Sidebar setzen; Marker-Popup zeigt Adresse

🤖 Generated with [Claude Code](https://claude.com/claude-code)