### PR TITLE
fix(kostenersatz): Verbrauchsmaterial nicht mit Stunden multiplizieren

### DIFF
--- a/src/common/kostenersatz.test.ts
+++ b/src/common/kostenersatz.test.ts
@@ -5,7 +5,29 @@ import {
   calculateCustomItemSum,
   roundCurrency,
   calculateTotalSum,
+  isHourlyRate,
+  effectiveStundenForRate,
+  recalculateLineItem,
+  KostenersatzRate,
+  KostenersatzLineItem,
 } from './kostenersatz';
+
+function makeRate(overrides: Partial<KostenersatzRate>): KostenersatzRate {
+  return {
+    id: '0.00',
+    version: 'test',
+    validFrom: '2023-01-01',
+    category: 'A',
+    categoryNumber: 1,
+    categoryName: 'Test',
+    description: 'Test',
+    unit: 'je Std',
+    price: 100,
+    isExtendable: false,
+    sortOrder: 0,
+    ...overrides,
+  };
+}
 
 describe('roundCurrency', () => {
   it('rounds to 2 decimal places', () => {
@@ -68,6 +90,88 @@ describe('calculateItemSum', () => {
   it('uses flat pricePauschal when price is 0', () => {
     // Tarif B/10: price=0, pricePauschal=50, einheiten=3 → 150
     expect(calculateItemSum(2, 3, 0, 50)).toBe(150);
+  });
+});
+
+describe('isHourlyRate', () => {
+  it('is hourly when unit contains an hourly indicator', () => {
+    expect(isHourlyRate(makeRate({ unit: 'je Std', price: 50 }))).toBe(true);
+    expect(isHourlyRate(makeRate({ unit: 'pro Person & h', price: 5 }))).toBe(
+      true,
+    );
+    expect(isHourlyRate(makeRate({ unit: 'EUR/h', price: 5 }))).toBe(true);
+  });
+
+  it('is hourly when it has both a per-hour price and a pauschal price', () => {
+    expect(
+      isHourlyRate(
+        makeRate({ unit: 'je Std', price: 100, pricePauschal: 800 }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is NOT hourly for per-unit Verbrauchsmaterial (e.g. pro Sack)', () => {
+    // Sack Ölbindemittel (12.05): price per Sack, no pauschal, per-unit
+    expect(isHourlyRate(makeRate({ unit: 'pro Sack', price: 49 }))).toBe(false);
+    expect(isHourlyRate(makeRate({ unit: 'pro Stück', price: 39 }))).toBe(
+      false,
+    );
+  });
+});
+
+describe('effectiveStundenForRate', () => {
+  it('returns the given hours for hourly rates', () => {
+    expect(effectiveStundenForRate(makeRate({ unit: 'je Std' }), 3)).toBe(3);
+  });
+
+  it('always returns 1 for per-unit rates regardless of hours', () => {
+    expect(
+      effectiveStundenForRate(makeRate({ unit: 'pro Sack', price: 49 }), 3),
+    ).toBe(1);
+  });
+});
+
+describe('recalculateLineItem', () => {
+  const baseItem: KostenersatzLineItem = {
+    rateId: '12.05',
+    einheiten: 1,
+    anzahlStunden: 1,
+    stundenOverridden: false,
+    sum: 0,
+  };
+
+  it('does NOT multiply per-unit Verbrauchsmaterial by the default hours', () => {
+    // Sack Ölbindemittel: 1 Sack × 49 = 49, even when defaultStunden is 3
+    const rate = makeRate({
+      id: '12.05',
+      unit: 'pro Sack',
+      price: 49,
+      categoryNumber: 12,
+    });
+    const result = recalculateLineItem(baseItem, rate, 3);
+    expect(result.sum).toBe(49);
+    expect(result.anzahlStunden).toBe(1);
+  });
+
+  it('applies the default hours to hourly rates', () => {
+    const rate = makeRate({ id: '1.01', unit: 'je Std', price: 100 });
+    const result = recalculateLineItem(baseItem, rate, 3);
+    // 1 unit × 3 hours × 100 = 300
+    expect(result.sum).toBe(300);
+    expect(result.anzahlStunden).toBe(3);
+  });
+
+  it('keeps the overridden hours when stundenOverridden is set', () => {
+    const rate = makeRate({ id: '1.01', unit: 'je Std', price: 100 });
+    const overridden: KostenersatzLineItem = {
+      ...baseItem,
+      anzahlStunden: 2,
+      stundenOverridden: true,
+    };
+    const result = recalculateLineItem(overridden, rate, 5);
+    // 1 unit × 2 hours × 100 = 200 (override wins over defaultStunden=5)
+    expect(result.sum).toBe(200);
+    expect(result.anzahlStunden).toBe(2);
   });
 });
 

--- a/src/common/kostenersatz.ts
+++ b/src/common/kostenersatz.ts
@@ -201,6 +201,38 @@ export function roundHoursForBilling(hours: number): number {
 }
 
 /**
+ * Check if a rate uses hourly pricing (the sum scales with the number of
+ * hours) vs. per-unit pricing such as Verbrauchsmaterial ("pro Sack",
+ * "pro Stück"). Per-unit rates are independent of the operation duration
+ * (defaultStunden) and must NOT be multiplied by the hours.
+ *
+ * Hourly rates either have both a per-hour price and a pauschal price, or
+ * their unit contains an hourly indicator ("je Std", "pro Person & h", "/h").
+ */
+export function isHourlyRate(rate: KostenersatzRate): boolean {
+  // If it has pricePauschal and an hourly rate, it's an hourly rate
+  if (rate.pricePauschal && rate.price > 0) {
+    return true;
+  }
+  // Check unit for hourly indicators
+  const hourlyUnits = ['je Std', 'pro Person & h', '/h'];
+  return hourlyUnits.some((u) => rate.unit.includes(u));
+}
+
+/**
+ * Effective billable hours for a rate. Per-unit rates (Verbrauchsmaterial)
+ * are always billed with 1 hour regardless of the operation duration, so that
+ * e.g. a single bag of oil binder stays at its unit price even when the
+ * default hours of the calculation are increased.
+ */
+export function effectiveStundenForRate(
+  rate: KostenersatzRate,
+  anzahlStunden: number,
+): number {
+  return isHourlyRate(rate) ? anzahlStunden : 1;
+}
+
+/**
  * Calculate the sum for a single line item based on hours and units
  *
  * Logic:
@@ -311,11 +343,13 @@ export function recalculateLineItem(
   defaultStunden: number,
 ): KostenersatzLineItem {
   const stunden = item.stundenOverridden ? item.anzahlStunden : defaultStunden;
+  // Verbrauchsmaterial (per-unit rates) is independent of the hours.
+  const effectiveStunden = effectiveStundenForRate(rate, stunden);
   return {
     ...item,
-    anzahlStunden: stunden,
+    anzahlStunden: effectiveStunden,
     sum: calculateItemSum(
-      stunden,
+      effectiveStunden,
       item.einheiten,
       rate.price,
       rate.pricePauschal,

--- a/src/components/Kostenersatz/KostenersatzCalculationPage.tsx
+++ b/src/components/Kostenersatz/KostenersatzCalculationPage.tsx
@@ -16,6 +16,7 @@ import {
   calculateTotalSum,
   createEmptyCalculation,
   createLineItem,
+  effectiveStundenForRate,
   KostenersatzCalculation,
   KostenersatzLineItem,
   KostenersatzCustomItem,
@@ -213,10 +214,12 @@ export default function KostenersatzCalculationPage({
             const rate = ratesById.get(item.rateId);
             if (rate) {
               const { calculateItemSum } = require('../../common/kostenersatz');
+              // Verbrauchsmaterial (per-unit rates) is independent of the hours.
+              const effectiveStunden = effectiveStundenForRate(rate, newStunden);
               return {
                 ...item,
-                anzahlStunden: newStunden,
-                sum: calculateItemSum(newStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours),
+                anzahlStunden: effectiveStunden,
+                sum: calculateItemSum(effectiveStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours),
               };
             }
           }

--- a/src/components/Kostenersatz/KostenersatzCategoryAccordion.tsx
+++ b/src/components/Kostenersatz/KostenersatzCategoryAccordion.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 import {
   formatCurrency,
+  isHourlyRate,
   KostenersatzCalculation,
   KostenersatzRate,
 } from '../../common/kostenersatz';
@@ -30,17 +31,6 @@ export interface KostenersatzCategoryAccordionProps {
   defaultExpanded?: boolean;
   customItemsTotal?: number;
   children?: React.ReactNode;
-}
-
-/**
- * Check if a rate uses hourly pricing
- */
-function isHourlyRate(rate: KostenersatzRate): boolean {
-  if (rate.pricePauschal && rate.price > 0) {
-    return true;
-  }
-  const hourlyUnits = ['je Std', 'pro Person & h', '/h'];
-  return hourlyUnits.some((u) => rate.unit.includes(u));
 }
 
 export default function KostenersatzCategoryAccordion({

--- a/src/components/Kostenersatz/KostenersatzDialog.tsx
+++ b/src/components/Kostenersatz/KostenersatzDialog.tsx
@@ -15,6 +15,7 @@ import {
   calculateSubtotals,
   calculateTotalSum,
   createEmptyCalculation,
+  effectiveStundenForRate,
   KostenersatzCalculation,
   KostenersatzLineItem,
   KostenersatzCustomItem,
@@ -154,10 +155,12 @@ export default function KostenersatzDialog({
             const rate = ratesById.get(item.rateId);
             if (rate) {
               const { calculateItemSum } = require('../../common/kostenersatz');
+              // Verbrauchsmaterial (per-unit rates) is independent of the hours.
+              const effectiveStunden = effectiveStundenForRate(rate, newStunden);
               return {
                 ...item,
-                anzahlStunden: newStunden,
-                sum: calculateItemSum(newStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours),
+                anzahlStunden: effectiveStunden,
+                sum: calculateItemSum(effectiveStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours),
               };
             }
           }

--- a/src/components/Kostenersatz/KostenersatzItemRow.tsx
+++ b/src/components/Kostenersatz/KostenersatzItemRow.tsx
@@ -13,6 +13,7 @@ import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import {
   formatCurrency,
+  isHourlyRate,
   KostenersatzLineItem,
   KostenersatzRate,
 } from '../../common/kostenersatz';
@@ -28,21 +29,6 @@ export interface KostenersatzItemRowProps {
     stundenOverridden: boolean
   ) => void;
   disabled?: boolean;
-}
-
-/**
- * Check if a rate uses hourly pricing (with optional pauschal) vs per-unit pricing
- * Hourly rates have pricePauschal and their unit contains "Std" or "h"
- * Per-unit rates (like "pro Stück", "pro Sack") don't use hours in calculation
- */
-function isHourlyRate(rate: KostenersatzRate): boolean {
-  // If it has pricePauschal and hourly rate, it's an hourly rate
-  if (rate.pricePauschal && rate.price > 0) {
-    return true;
-  }
-  // Check unit for hourly indicators
-  const hourlyUnits = ['je Std', 'pro Person & h', '/h'];
-  return hourlyUnits.some((u) => rate.unit.includes(u));
 }
 
 export default function KostenersatzItemRow({

--- a/src/components/Kostenersatz/KostenersatzTemplateDialog.tsx
+++ b/src/components/Kostenersatz/KostenersatzTemplateDialog.tsx
@@ -24,6 +24,7 @@ import {
   calculateTotalSum,
   calculateSubtotals,
   createLineItem,
+  effectiveStundenForRate,
   formatCurrency,
 } from '../../common/kostenersatz';
 import {
@@ -57,13 +58,17 @@ function buildCalculationFromTemplate(
   const ratesById = new Map(rates.map((r) => [r.id, r]));
   const lineItems: KostenersatzLineItem[] = items.map((item) => {
     const rate = ratesById.get(item.rateId);
+    // Verbrauchsmaterial (per-unit rates) is independent of the hours.
+    const effectiveStunden = rate
+      ? effectiveStundenForRate(rate, defaultStunden)
+      : defaultStunden;
     return {
       rateId: item.rateId,
       einheiten: item.einheiten,
-      anzahlStunden: defaultStunden,
+      anzahlStunden: effectiveStunden,
       stundenOverridden: false,
       sum: rate
-        ? calculateItemSum(defaultStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours)
+        ? calculateItemSum(effectiveStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours)
         : 0,
     };
   });
@@ -324,12 +329,13 @@ export default function KostenersatzTemplateDialog({
                 const newItems = prev.items.map((item) => {
                   if (item.stundenOverridden) return item;
                   const rate = ratesById.get(item.rateId);
+                  if (!rate) return item;
+                  // Verbrauchsmaterial (per-unit rates) is independent of the hours.
+                  const effectiveStunden = effectiveStundenForRate(rate, newStunden);
                   return {
                     ...item,
-                    anzahlStunden: newStunden,
-                    sum: rate
-                      ? calculateItemSum(newStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours)
-                      : item.sum,
+                    anzahlStunden: effectiveStunden,
+                    sum: calculateItemSum(effectiveStunden, item.einheiten, rate.price, rate.pricePauschal, rate.pauschalHours),
                   };
                 });
                 const subtotals = calculateSubtotals(newItems, rates);


### PR DESCRIPTION
## Zusammenfassung

Beim Kostenersatz wurden zusätzliche Verbrauchsmaterialien (per-Stück-/Sack-Tarife wie „Sack Ölbindemittel" 12.05) fälschlich mit der globalen Stundenzahl multipliziert. Stellte man die Stunden z.B. auf 3, kostete 1 Sack Ölbindemittel das Dreifache. Verbrauchsmaterial ist jedoch unabhängig von der Einsatzdauer.

Ursache: Beim Ändern der globalen `defaultStunden` wurden alle nicht-übersteuerten Line-Items mit den neuen Stunden neu berechnet — auch per-Einheit-Tarife. Die Unterscheidung „stündlich vs. pro Einheit" (`isHourlyRate`) existierte nur in der UI-Anzeige, nicht in den Recalc-Pfaden.

## Änderungen

- `isHourlyRate` zentral nach `src/common/kostenersatz.ts` verschoben und exportiert (war dupliziert in `KostenersatzItemRow` und `KostenersatzCategoryAccordion`).
- Neuer Helper `effectiveStundenForRate(rate, stunden)`: per-Einheit-Tarife werden immer mit 1 Stunde abgerechnet.
- Helper in allen Recalc-Pfaden angewandt: `recalculateLineItem`, die Stunden-Handler in `KostenersatzCalculationPage`, `KostenersatzDialog`, `KostenersatzTemplateDialog` sowie `buildCalculationFromTemplate`.
- Tests für `isHourlyRate`, `effectiveStundenForRate` und `recalculateLineItem` ergänzt.

## Test plan

- [x] `npx vitest run src/common/kostenersatz.test.ts` (24 Tests grün)
- [x] `npx tsc --noEmit` ohne Fehler
- [x] `npx eslint` der geänderten Dateien ohne Fehler
- [x] `npx next build --webpack` erfolgreich
- [ ] In der App: Stunden auf 3 stellen, 1 Sack Ölbindemittel hinzufügen → Betrag bleibt beim Einheitspreis (z.B. 49 €), wird nicht ×3 multipliziert
- [ ] Stündliche Tarife (z.B. Fahrzeuge) werden weiterhin korrekt mit den Stunden multipliziert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaqHSqSkmQcXDDxNG9BUqH)_