### PR TITLE
fix(kostenersatz): erst bei Versand/Abschließen schließen, Verrechnungsart editierbar

### DIFF
--- a/src/components/Kostenersatz/KostenersatzCalculationPage.tsx
+++ b/src/components/Kostenersatz/KostenersatzCalculationPage.tsx
@@ -667,7 +667,6 @@ export default function KostenersatzCalculationPage({
             <KostenersatzEmpfaengerTab
               recipient={calculation.recipient}
               onChange={handleRecipientChange}
-              disabled={!isEditable}
               firecallId={firecallId}
               calculationId={existingCalculation?.id || calculation.id}
               sumupPaymentStatus={calculation.sumupPaymentStatus}

--- a/src/components/Kostenersatz/KostenersatzCalculationPage.tsx
+++ b/src/components/Kostenersatz/KostenersatzCalculationPage.tsx
@@ -429,8 +429,10 @@ export default function KostenersatzCalculationPage({
     }
   }, [existingCalculation?.id, calculation.id, calculation.recipient, firecallId]);
 
-  // Save before SumUp payment — saves as draft and returns the new calculationId
-  const handleSaveBeforePayment = useCallback(async (): Promise<string | undefined> => {
+  // Persist the current calculation while preserving its status, returning the
+  // calculationId. Used before a SumUp payment and before sending the invoice
+  // email so the server always works with the latest data.
+  const persistCalculation = useCallback(async (): Promise<string | undefined> => {
     setIsSaving(true);
     try {
       const calcToSave = {
@@ -505,20 +507,23 @@ export default function KostenersatzCalculationPage({
     [calculation, existingCalculation, addCalculation, updateCalculation, router, firecallId]
   );
 
-  // Email button handler - completes the calculation first if needed, then opens email dialog
+  // Email button handler - opens the email dialog. The calculation stays an
+  // editable draft until the invoice is actually sent; sending it (in the dialog)
+  // is what closes the calculation.
+  //
+  // The current calculation is always persisted first (preserving its status):
+  // the email's PDF is rendered server-side from the Firestore document, so any
+  // unsaved local edits (e.g. a changed Verrechnungsart) must be saved before
+  // sending — otherwise the invoice would reflect stale data. This also gives a
+  // brand-new calculation an id to send from.
   const handleEmailClick = useCallback(async () => {
-    const isNewOrDraft = !existingCalculation?.id && !calculation.id || calculation.status === 'draft';
-
-    if (isNewOrDraft) {
-      // Save and complete the calculation first
-      const success = await handleSave('completed', false, false);
-      if (!success) {
-        return; // Save failed, don't open email dialog
-      }
+    const savedId = await persistCalculation();
+    if (!savedId) {
+      return; // Save failed, don't open email dialog
     }
 
     setEmailDialogOpen(true);
-  }, [existingCalculation?.id, calculation.id, calculation.status, handleSave]);
+  }, [persistCalculation]);
 
   // Copy button handler - creates a draft copy and navigates to it
   const handleCopy = useCallback(async () => {
@@ -670,7 +675,7 @@ export default function KostenersatzCalculationPage({
               firecallId={firecallId}
               calculationId={existingCalculation?.id || calculation.id}
               sumupPaymentStatus={calculation.sumupPaymentStatus}
-              onSaveBeforePayment={handleSaveBeforePayment}
+              onSaveBeforePayment={persistCalculation}
             />
           </TabPanel>
         </Box>
@@ -769,7 +774,11 @@ export default function KostenersatzCalculationPage({
         <KostenersatzEmailDialog
           open={emailDialogOpen}
           onClose={() => setEmailDialogOpen(false)}
-          onSuccess={() => setSuccessMessage(t('emailSent'))}
+          onSuccess={() => {
+            // Sending the invoice closes the calculation.
+            setCalculation((prev) => ({ ...prev, status: 'completed' }));
+            setSuccessMessage(t('emailSent'));
+          }}
           calculation={calculation as KostenersatzCalculation}
           firecall={firecall}
           firecallId={firecallId}

--- a/src/components/Kostenersatz/KostenersatzDialog.tsx
+++ b/src/components/Kostenersatz/KostenersatzDialog.tsx
@@ -323,7 +323,6 @@ export default function KostenersatzDialog({
             <KostenersatzEmpfaengerTab
               recipient={calculation.recipient}
               onChange={handleRecipientChange}
-              disabled={!isEditable}
             />
           </TabPanel>
         </Box>

--- a/src/components/Kostenersatz/KostenersatzEmpfaengerTab.tsx
+++ b/src/components/Kostenersatz/KostenersatzEmpfaengerTab.tsx
@@ -36,7 +36,6 @@ import { createSumupCheckout, getSumupDeepLink, checkSumupPaymentStatus } from '
 export interface KostenersatzEmpfaengerTabProps {
   recipient: KostenersatzRecipient;
   onChange: (recipient: KostenersatzRecipient) => void;
-  disabled?: boolean;
   firecallId?: string;
   calculationId?: string;
   sumupPaymentStatus?: string;
@@ -65,7 +64,6 @@ function PaymentStatusChip({ status }: { status: string }) {
 export default function KostenersatzEmpfaengerTab({
   recipient,
   onChange,
-  disabled = false,
   firecallId,
   calculationId,
   sumupPaymentStatus,
@@ -261,7 +259,7 @@ export default function KostenersatzEmpfaengerTab({
         placeholder={t('emailPlaceholder')}
       />
 
-      <FormControl fullWidth disabled={disabled}>
+      <FormControl fullWidth>
         <InputLabel id="payment-method-label">{t('paymentMethod')}</InputLabel>
         <Select
           labelId="payment-method-label"

--- a/src/components/Kostenersatz/completePaymentAndNotify.test.ts
+++ b/src/components/Kostenersatz/completePaymentAndNotify.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// --- Firestore admin mock -------------------------------------------------
+const calcGet = vi.fn();
+const calcUpdate = vi.fn().mockResolvedValue(undefined);
+const firecallGet = vi.fn();
+const configGet = vi.fn();
+const ratesGet = vi.fn();
+
+const calcDocRef = { get: calcGet, update: calcUpdate };
+const subColl = { doc: vi.fn(() => calcDocRef) };
+const firecallDocRef = { collection: vi.fn(() => subColl), get: firecallGet };
+const firecallColl = { doc: vi.fn(() => firecallDocRef) };
+const configColl = { doc: vi.fn(() => ({ get: configGet })) };
+const ratesColl = { where: vi.fn(() => ({ get: ratesGet })) };
+
+const mockCollection = vi.fn((name: string) => {
+  switch (name) {
+    case 'kostenersatzConfig':
+      return configColl;
+    case 'call':
+      return firecallColl;
+    case 'kostenersatzRates':
+      return ratesColl;
+    default:
+      return { doc: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })) };
+  }
+});
+
+vi.mock('../../server/firebase/admin', () => ({
+  firestore: { collection: (...args: unknown[]) => mockCollection(...(args as [string])) },
+}));
+
+vi.mock('../firebase/firestore', () => ({
+  FIRECALL_COLLECTION_ID: 'call',
+}));
+
+const sendMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('@googleapis/gmail', () => ({
+  gmail: () => ({ users: { messages: { send: sendMock } } }),
+}));
+
+vi.mock('../../server/auth/workspace', () => ({
+  createWorkspaceAuth: () => ({}),
+}));
+
+vi.mock('@react-pdf/renderer', () => ({
+  renderToBuffer: vi.fn().mockResolvedValue(Buffer.from('pdf')),
+}));
+
+vi.mock('./KostenersatzPdf', () => ({
+  default: () => ({}),
+}));
+
+import { completePaymentAndNotify } from './completePaymentAndNotify';
+
+function draftCalculation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'calc1',
+    status: 'draft',
+    rateVersion: 'LGBl_77_2023',
+    recipient: { name: 'Max Mustermann', email: 'kunde@example.com' },
+    items: [],
+    customItems: [],
+    totalSum: 100,
+    comment: '',
+    ...overrides,
+  };
+}
+
+const firecallData = { id: 'fc1', name: 'Einsatz 1', date: '2024-01-01' };
+
+describe('completePaymentAndNotify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_SERVICE_ACCOUNT = 'sa';
+    process.env.EINSATZMAPPE_IMPERSONATION_ACCOUNT = 'me@example.com';
+    firecallGet.mockResolvedValue({ exists: true, id: 'fc1', data: () => firecallData });
+    configGet.mockResolvedValue({ exists: false }); // -> DEFAULT_EMAIL_CONFIG (has ccEmail)
+    ratesGet.mockResolvedValue({ empty: true, docs: [] });
+  });
+
+  it('closes the calculation as completed only after the email is sent', async () => {
+    calcGet.mockResolvedValue({ exists: true, id: 'calc1', data: () => draftCalculation() });
+
+    const result = await completePaymentAndNotify('fc1', 'calc1');
+
+    expect(result).toBe(true);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    // Status is only written once — after the mail went out — and it is 'completed'.
+    expect(calcUpdate).toHaveBeenCalledTimes(1);
+    const update = calcUpdate.mock.calls[0][0];
+    expect(update.status).toBe('completed');
+    expect(update.emailSentAt).toBeTruthy();
+  });
+
+  it('does NOT close the calculation when no email can be sent (no recipient/cc email)', async () => {
+    configGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        fromEmail: 'from@example.com',
+        ccEmail: '',
+        subjectTemplate: 'S',
+        bodyTemplate: 'B',
+      }),
+    });
+    calcGet.mockResolvedValue({
+      exists: true,
+      id: 'calc1',
+      data: () => draftCalculation({ recipient: { name: 'Max', email: '' } }),
+    });
+
+    const result = await completePaymentAndNotify('fc1', 'calc1');
+
+    expect(result).toBe(false);
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(calcUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT close the calculation when sending the email fails', async () => {
+    calcGet.mockResolvedValue({ exists: true, id: 'calc1', data: () => draftCalculation() });
+    sendMock.mockRejectedValueOnce(new Error('Gmail down'));
+
+    const result = await completePaymentAndNotify('fc1', 'calc1');
+
+    expect(result).toBe(false);
+    expect(calcUpdate).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent for already completed calculations', async () => {
+    calcGet.mockResolvedValue({
+      exists: true,
+      id: 'calc1',
+      data: () => draftCalculation({ status: 'completed' }),
+    });
+
+    const result = await completePaymentAndNotify('fc1', 'calc1');
+
+    expect(result).toBe(false);
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(calcUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Kostenersatz/completePaymentAndNotify.ts
+++ b/src/components/Kostenersatz/completePaymentAndNotify.ts
@@ -151,12 +151,18 @@ function buildEmailMessage(
 // ============================================================================
 
 /**
- * Idempotently close a paid Kostenersatz calculation and send an email notification.
+ * Idempotently send the invoice email for a paid Kostenersatz calculation and,
+ * once the email has actually gone out, close the calculation (status `completed`).
  *
  * Called from: SumUp webhook, poll action, and redirect page.
  *
- * Returns `true` if the calculation was newly completed (or was already completed),
- * `false` if it was already in a terminal state (completed/sent) -- i.e. no work was done.
+ * The calculation is ONLY closed when the invoice email was sent successfully.
+ * If no email can be sent (no recipient/cc address, email service not configured,
+ * or the send fails), the calculation stays an editable draft and is NOT closed
+ * automatically — a paid SumUp checkout alone never locks the calculation.
+ *
+ * Returns `true` if the invoice was sent and the calculation was closed,
+ * `false` otherwise (already terminal, nothing sent, or send failed).
  */
 export async function completePaymentAndNotify(
   firecallId: string,
@@ -191,15 +197,8 @@ export async function completePaymentAndNotify(
     return false;
   }
 
-  // 3. Set status to 'completed'
-  const now = new Date().toISOString();
-  await calculationRef.update({
-    status: 'completed',
-    updatedAt: now,
-  });
-  calculation.status = 'completed';
-
-  // 4. Load firecall, email config, and rates
+  // 3. Load firecall, email config, and rates (needed to decide whether an
+  //    invoice email can be sent — the calculation is only closed if it can).
   const firecallDoc = await firestore
     .collection(FIRECALL_COLLECTION_ID)
     .doc(firecallId)
@@ -207,9 +206,9 @@ export async function completePaymentAndNotify(
 
   if (!firecallDoc.exists) {
     console.error(
-      `[completePaymentAndNotify] Firecall ${firecallId} not found`
+      `[completePaymentAndNotify] Firecall ${firecallId} not found. Calculation ${calculationId} stays a draft.`
     );
-    return true; // Calculation was still closed
+    return false; // No email possible -> do not close.
   }
 
   const firecall = {
@@ -222,7 +221,7 @@ export async function completePaymentAndNotify(
     loadRatesForVersion(calculation.rateVersion),
   ]);
 
-  // 5. Determine email recipient
+  // 4. Determine email recipient
   const recipientEmail = calculation.recipient?.email;
   const ccEmail = emailConfig.ccEmail;
 
@@ -239,31 +238,31 @@ export async function completePaymentAndNotify(
     ccAddresses = undefined;
   } else {
     console.warn(
-      `[completePaymentAndNotify] No recipient email and no ccEmail configured for calculation ${calculationId}. Calculation closed without email.`
+      `[completePaymentAndNotify] No recipient email and no ccEmail configured for calculation ${calculationId}. Calculation stays an editable draft (not closed).`
     );
-    return true;
+    return false; // No email possible -> do not close.
   }
 
-  // 6. Check that email service is configured
+  // 5. Check that email service is configured
   if (!process.env.GOOGLE_SERVICE_ACCOUNT || !process.env.EINSATZMAPPE_IMPERSONATION_ACCOUNT) {
     console.warn(
-      `[completePaymentAndNotify] Email service not configured (missing GOOGLE_SERVICE_ACCOUNT or EINSATZMAPPE_IMPERSONATION_ACCOUNT). Calculation ${calculationId} closed without email.`
+      `[completePaymentAndNotify] Email service not configured (missing GOOGLE_SERVICE_ACCOUNT or EINSATZMAPPE_IMPERSONATION_ACCOUNT). Calculation ${calculationId} stays an editable draft (not closed).`
     );
-    return true;
+    return false; // No email possible -> do not close.
   }
 
   try {
-    // 7. Render email subject and body using templates
+    // 6. Render email subject and body using templates
     const templateContext = buildTemplateContext(calculation, firecall);
     const { subject, body } = renderEmailTemplates(emailConfig, templateContext);
 
-    // 8. Generate PDF
+    // 7. Generate PDF
     const pdfBuffer = await generatePdfBuffer(calculation, rates, firecall);
 
     // Create filename for attachment
     const filename = `Kostenersatz_${firecall.name.replace(/[^a-zA-Z0-9]/g, '_')}_${calculation.recipient.name.replace(/[^a-zA-Z0-9]/g, '_')}.pdf`;
 
-    // 9. Build RFC 2822 email and send via Gmail API
+    // 8. Build RFC 2822 email and send via Gmail API
     const impersonationAccount = process.env.EINSATZMAPPE_IMPERSONATION_ACCOUNT!;
     const rawMessage = buildEmailMessage(
       toAddress,
@@ -298,24 +297,26 @@ export async function completePaymentAndNotify(
       },
     });
 
-    // 10. Update status to 'sent' with timestamp
+    // 9. Email sent successfully -> close the calculation as 'completed'.
     const emailSentAt = new Date().toISOString();
     await calculationRef.update({
-      status: 'sent',
+      status: 'completed',
       emailSentAt,
       updatedAt: emailSentAt,
     });
 
     console.log(
-      `[completePaymentAndNotify] Email sent for calculation ${calculationId} to ${toAddress}`
+      `[completePaymentAndNotify] Email sent for calculation ${calculationId} to ${toAddress}; calculation closed.`
     );
+
+    return true;
   } catch (error: any) {
-    // 11. Email failure: log but don't throw. Calculation stays 'completed'.
+    // 10. Email failure: log but don't throw. The calculation stays an editable
+    //     draft (NOT closed) so it can be retried / sent manually.
     console.error(
-      `[completePaymentAndNotify] Failed to send email for calculation ${calculationId}:`,
+      `[completePaymentAndNotify] Failed to send email for calculation ${calculationId}; calculation stays a draft:`,
       error?.message || error
     );
+    return false;
   }
-
-  return true;
 }

--- a/src/components/Kostenersatz/kostenersatzEmailAction.test.ts
+++ b/src/components/Kostenersatz/kostenersatzEmailAction.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// --- Firestore admin mock -------------------------------------------------
+const calcGet = vi.fn();
+const calcUpdate = vi.fn().mockResolvedValue(undefined);
+const configGet = vi.fn();
+const ratesGet = vi.fn();
+
+const calcDocRef = { get: calcGet, update: calcUpdate };
+const subColl = { doc: vi.fn(() => calcDocRef) };
+const firecallDocRef = { collection: vi.fn(() => subColl) };
+const firecallColl = { doc: vi.fn(() => firecallDocRef) };
+const configColl = { doc: vi.fn(() => ({ get: configGet })) };
+const ratesColl = { where: vi.fn(() => ({ get: ratesGet })) };
+
+const mockCollection = vi.fn((name: string) => {
+  switch (name) {
+    case 'kostenersatzConfig':
+      return configColl;
+    case 'call':
+      return firecallColl;
+    case 'kostenersatzRates':
+      return ratesColl;
+    default:
+      return { doc: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })) };
+  }
+});
+
+vi.mock('../../server/firebase/admin', () => ({
+  firestore: { collection: (...args: unknown[]) => mockCollection(...(args as [string])) },
+}));
+
+vi.mock('../firebase/firestore', () => ({
+  FIRECALL_COLLECTION_ID: 'call',
+}));
+
+const actionAuthMock = vi.fn();
+vi.mock('../../app/auth', () => ({
+  actionUserAuthorizedForFirecall: () => actionAuthMock(),
+}));
+
+const sendMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('@googleapis/gmail', () => ({
+  gmail: () => ({ users: { messages: { send: sendMock } } }),
+}));
+
+vi.mock('../../server/auth/workspace', () => ({
+  createWorkspaceAuth: () => ({}),
+}));
+
+vi.mock('@react-pdf/renderer', () => ({
+  renderToBuffer: vi.fn().mockResolvedValue(Buffer.from('pdf')),
+}));
+
+vi.mock('./KostenersatzPdf', () => ({
+  default: () => ({}),
+}));
+
+import { sendKostenersatzEmailAction } from './kostenersatzEmailAction';
+
+const baseRequest = {
+  firecallId: 'fc1',
+  calculationId: 'calc1',
+  to: 'kunde@example.com',
+  cc: [],
+  subject: 'Kostenersatz',
+  body: 'Rechnung anbei',
+};
+
+function draftCalculation() {
+  return {
+    id: 'calc1',
+    status: 'draft',
+    rateVersion: 'LGBl_77_2023',
+    recipient: { name: 'Max Mustermann', email: 'kunde@example.com' },
+    items: [],
+    customItems: [],
+    totalSum: 100,
+    comment: '',
+  };
+}
+
+describe('sendKostenersatzEmailAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_SERVICE_ACCOUNT = 'sa';
+    process.env.EINSATZMAPPE_IMPERSONATION_ACCOUNT = 'me@example.com';
+    actionAuthMock.mockResolvedValue({ id: 'fc1', name: 'Einsatz 1', date: '2024-01-01' });
+    configGet.mockResolvedValue({ exists: false });
+    ratesGet.mockResolvedValue({ empty: true, docs: [] });
+  });
+
+  it('sends the invoice for a draft calculation (no longer rejected)', async () => {
+    calcGet.mockResolvedValue({ exists: true, id: 'calc1', data: () => draftCalculation() });
+
+    const result = await sendKostenersatzEmailAction(baseRequest);
+
+    expect(result.success).toBe(true);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the calculation as completed (not sent) after sending', async () => {
+    calcGet.mockResolvedValue({ exists: true, id: 'calc1', data: () => draftCalculation() });
+
+    await sendKostenersatzEmailAction(baseRequest);
+
+    expect(calcUpdate).toHaveBeenCalledTimes(1);
+    const update = calcUpdate.mock.calls[0][0];
+    expect(update.status).toBe('completed');
+    expect(update.emailSentAt).toBeTruthy();
+  });
+});

--- a/src/components/Kostenersatz/kostenersatzEmailAction.ts
+++ b/src/components/Kostenersatz/kostenersatzEmailAction.ts
@@ -138,13 +138,9 @@ export async function sendKostenersatzEmailAction(
       ...calculationDoc.data(),
     } as KostenersatzCalculation;
 
-    // Check calculation status - only allow sending for completed or sent
-    if (calculation.status === 'draft') {
-      return {
-        success: false,
-        error: 'Cannot send email for draft calculations. Please complete the calculation first.',
-      };
-    }
+    // A calculation stays editable (draft) until the invoice is actually sent or it
+    // is completed manually. Sending the invoice is therefore allowed from any status
+    // and is the action that closes the calculation (see status update below).
 
     // Load rates for the calculation's version
     let rates: KostenersatzRate[] = [];
@@ -212,10 +208,10 @@ export async function sendKostenersatzEmailAction(
       },
     });
 
-    // Update calculation status
+    // Update calculation status: sending the invoice closes the calculation.
     const emailSentAt = new Date().toISOString();
     await calculationRef.update({
-      status: 'sent',
+      status: 'completed',
       emailSentAt,
       updatedAt: emailSentAt,
     });


### PR DESCRIPTION
## Zusammenfassung

Der Kostenersatz bleibt jetzt **editierbar (`draft`)**, bis er **explizit** geschlossen wird – entweder durch den **„Abschließen"-Button** oder durch den **tatsächlichen Versand der Rechnung**. Eine bezahlte SumUp-Online-Zahlung schließt den Kostenersatz **nicht mehr automatisch**.

Außerdem behebt der Branch die ursprünglich gemeldete Einschränkung, dass die **Verrechnungs-/Zahlungsart** (`paymentMethod`) nach Verlassen des `draft`-Status nicht mehr änderbar war.

## Änderungen

### Schließen nur bei Versand oder „Abschließen"

- **`completePaymentAndNotify`** (SumUp-Auto-Flow: Webhook, Poll, Redirect): Der Status wird **erst nach erfolgreichem E-Mail-Versand** auf `completed` gesetzt. Kann keine Mail versandt werden (keine Empfänger-/CC-Adresse, Mail-Service nicht konfiguriert, oder Versand schlägt fehl), bleibt die Berechnung ein **editierbarer Entwurf** und wird **nicht** gesperrt. Die reine Zahlungserfassung (`sumupPaymentStatus: 'paid'`) bleibt unverändert.
- **`sendKostenersatzEmailAction`**: Versand ist jetzt auch aus einem Entwurf möglich (Sperre „Cannot send email for draft calculations" entfernt). Nach Versand wird der Status auf `completed` gesetzt (statt `sent`).
- **`KostenersatzCalculationPage`**: Der „E-Mail"-Button schließt den Entwurf **nicht mehr vorab** ab – erst der tatsächliche Versand schließt ab. Nach erfolgreichem Versand wird die UI sofort gesperrt.

### Vor Versand wird automatisch gespeichert

- Vor dem Öffnen/Versenden wird die Berechnung **immer gespeichert** (statuserhaltend). Hintergrund: Die PDF im E-Mail wird **serverseitig aus dem Firestore-Dokument** gerendert. Ohne vorheriges Speichern landeten lokale Änderungen (z. B. eine geänderte Verrechnungsart) nicht in der Rechnung – die PDF zeigte z. B. „Rechnung: Betrag ausständig" statt „Kreditkarte: Betrag eingehoben".
- Die bisherige „vor Zahlung speichern"-Funktion wurde zu `persistCalculation` verallgemeinert und wird nun für **beide** Fälle (SumUp-Zahlung und E-Mail-Versand) genutzt.

### Verrechnungsart dauerhaft editierbar (ursprünglicher Fix)

- Das `disabled`-Flag der Verrechnungsart-Auswahl im Empfänger-Tab wurde entfernt; das nicht mehr benötigte `disabled`-Prop wurde aus `KostenersatzEmpfaengerTab` und allen Aufrufstellen entfernt.

### Tests

- Neue Tests für `sendKostenersatzEmailAction` (Versand aus Entwurf, Status `completed`).
- Neue Tests für `completePaymentAndNotify` (Schließen nur bei erfolgreichem Versand, kein Schließen ohne mögliche Mail / bei Versandfehler, Idempotenz).

> Hinweis: Der Status `'sent'` bleibt im Typ für Altdaten erhalten (Anzeige/Editierbarkeit funktionieren weiter), wird aber nicht mehr neu gesetzt.

## Test plan

- [ ] Entwurf: Verrechnungsart ändern → ohne weiteres Speichern „E-Mail" → versenden → PDF zeigt korrekte Verrechnungsart (z. B. „Kreditkarte: Betrag eingehoben")
- [ ] Entwurf bleibt editierbar, bis „Abschließen" geklickt oder Rechnung versandt wird
- [ ] „Abschließen" → Status `completed`, Berechnung gesperrt (Verrechnungsart bleibt editierbar)
- [ ] Rechnung per E-Mail versenden → Status `completed`, Berechnung gesperrt
- [ ] SumUp-Online-Zahlung bezahlt, Empfänger hat E-Mail-Adresse → Rechnung wird automatisch versandt und Berechnung geschlossen
- [ ] SumUp-Online-Zahlung bezahlt, aber keine Mail möglich → Berechnung bleibt editierbarer Entwurf (nicht automatisch geschlossen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
