### PR TITLE
fix(android): connectedDevice-FGS-Typ nur bei aktiver Radiacode-Session

### DIFF
--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt
@@ -172,6 +172,17 @@ class RadiacodeForegroundService : Service() {
     @Volatile private var currentAddress: String? = null
     @Volatile private var deviceReady = false
 
+    // True, sobald eine Radiacode-BLE-Verbindung angefordert wurde und bis der
+    // User explizit trennt (ACTION_BLE_DISCONNECT → teardownSession) oder der
+    // Service stirbt. NUR in diesem Zustand darf der Foreground-Service den Typ
+    // CONNECTED_DEVICE führen. Reine GPS-Track-/Live-Share-Modi (kein Gerät
+    // verbunden) laufen als reiner LOCATION-Service — sonst deklariert der
+    // Service connectedDevice für einen Use-Case, der kein Gerät verbindet, was
+    // gegen die Play-FGS-Policy verstößt (Reject 2026-06, version code 1319).
+    // Bleibt über Reconnect-Versuche hinweg gesetzt (handleConnectionLost lässt
+    // es unberührt), damit der Typ während eines Reconnects nicht kippt.
+    @Volatile private var bleSessionActive = false
+
     /** Single-thread worker für blockierende BLE-Calls (Connect-Handshake + execute). */
     private var bleWorker: ExecutorService? = null
 
@@ -274,6 +285,13 @@ class RadiacodeForegroundService : Service() {
         // Variante mit Service-Typ aufgerufen werden, sonst crasht der Service
         // mit MissingForegroundServiceTypeException — und reisst unsere
         // BLE-Session mit sich. Siehe Bug-Report vom 2026-04-22.
+        // CONNECTED_DEVICE-Typ ab dem Connect-Request aktivieren — der gemeinsame
+        // ensureForeground()-Aufruf unten läuft VOR dem when-Block, also muss das
+        // Flag hier gesetzt sein, damit der erste startForeground() den Typ schon
+        // korrekt führt.
+        if (action == ACTION_BLE_CONNECT) {
+            bleSessionActive = true
+        }
         if (action != null && action != ACTION_STOP && action != ACTION_DISCONNECT_REQUESTED) {
             ensureForeground()
         }
@@ -514,7 +532,13 @@ class RadiacodeForegroundService : Service() {
      */
     private fun resolveForegroundServiceType(): Int {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return 0
-        var type = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+        var type = 0
+        // CONNECTED_DEVICE nur bei aktiver Radiacode-BLE-Session — sonst würde
+        // der Service den Typ auch für reine GPS-Track-/Live-Share-Läufe führen,
+        // bei denen kein Gerät verbunden ist (Play-FGS-Policy-Verstoß).
+        if (bleSessionActive) {
+            type = type or ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+        }
         val fine = ContextCompat.checkSelfPermission(
             this, Manifest.permission.ACCESS_FINE_LOCATION,
         )
@@ -875,6 +899,10 @@ class RadiacodeForegroundService : Service() {
         transport = null
         currentAddress = null
         deviceReady = false
+        // BLE-Session beendet → CONNECTED_DEVICE-Typ darf nicht weiter geführt
+        // werden. Ein evtl. noch laufender GPS-Track/Live-Share-Modus stuft den
+        // Service beim nächsten ensureForeground() auf reines LOCATION zurück.
+        bleSessionActive = false
         // Reconnect-Counter zurücksetzen — beim nächsten manuellen Connect
         // soll der Backoff wieder beim kürzesten Delay anfangen. Der laufende
         // Reconnect-Worker (falls einer geplant ist) stoppt sich selbst, weil


### PR DESCRIPTION
## Zusammenfassung

Google Play hat die App (version code 1319) wegen eines Foreground-Service-Policy-Verstoßes abgelehnt. Beanstandet wurde ausschließlich der FGS-Typ **`connectedDevice`** („Connected Device – Connected Device Other"), den die App für die Radiacode-BLE-Verbindung nutzt.

Ursache im Code: `RadiacodeForegroundService.resolveForegroundServiceType()` hat `FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE` **bedingungslos** gesetzt — also auch dann, wenn der Service nur für **GPS-Track-Aufzeichnung** oder **Live-Standort-Teilen** läuft und gar kein BLE-Gerät verbunden ist. Damit wurde der connectedDevice-Typ für Use-Cases geführt, die kein Gerät verbinden und nicht geräte-perzeptibel sind — genau Googles Beanstandung („using foreground service to Connected Device when it is not required to do so" / nicht perzeptibel / Deklaration passt nicht zum App-Erlebnis).

## Änderungen

- Neues Flag `bleSessionActive`, das ab `ACTION_BLE_CONNECT` gesetzt und erst bei `teardownSession()` (User-Disconnect / `onDestroy`) zurückgesetzt wird. Über Reconnect-Versuche hinweg bleibt es gesetzt (`handleConnectionLost()` lässt es unberührt), damit der FGS-Typ während eines Reconnects nicht kippt.
- `resolveForegroundServiceType()` setzt `FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE` nur noch bei aktiver Radiacode-BLE-Session. Reine GPS-Track-/Live-Share-Modi laufen als reiner `LOCATION`-Service.
- Das Flag wird vor dem gemeinsamen `ensureForeground()`-Aufruf gesetzt, damit schon der erste `startForeground()` den korrekten Typ führt (kein `MissingForegroundServiceTypeException`-Risiko).
- Manifest unverändert: `foregroundServiceType="connectedDevice|location"` bleibt als Vereinigungsmenge aller möglichen Typen; die `FOREGROUND_SERVICE_CONNECTED_DEVICE`-Berechtigung bleibt, weil der BLE-Use-Case sie weiterhin legitim braucht.

## Test plan

- [ ] Android-Build mit JDK 21 (`:app:assembleDebug`) erfolgreich (lokal/CI — im Web-Env nicht möglich, da `dl.google.com` durch den Proxy geblockt wird)
- [ ] BLE-Connect → Notification zeigt Live-Messwerte; in den Logs `ensureForeground type=0x...` enthält connectedDevice (+ location)
- [ ] Reiner GPS-Track ohne Radiacode → `ensureForeground type` ist **nur** location (kein connectedDevice)
- [ ] Reines Live-Standort-Teilen ohne Radiacode → `ensureForeground type` ist **nur** location
- [ ] BLE-Disconnect bei laufendem GPS-Track → Typ stuft auf location zurück, Service läuft weiter
- [ ] Reconnect-Phase nach BLE-Verbindungsverlust → Typ bleibt connectedDevice

## Play-Console-seitig (separat, nicht Teil dieses PRs)

Diese Schritte müssen zusätzlich manuell in der Play Console erfolgen:
- FGS-Deklaration neu einreichen, sodass connectedDevice nur den Radiacode-Use-Case beschreibt und GPS/Live-Share als location deklariert sind.
- Demo-Video, das den connectedDevice-Use-Case zeigt (User startet Radiacode-Verbindung → Notification mit Live-µSv/h → Hintergrund/Sperrbildschirm → Messung läuft weiter → User trennt). Hardware-Abhängigkeit (Radiacode-Dosimeter) erläutern.
- Neuen Build mit höherem version code hochladen; version code 1319 deaktivieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzLZ888HKZZC2kNortHv6Q)_