### PR TITLE
feat(ci): automatisches Android-Test-Release bei Push auf main

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,6 +1,11 @@
 name: "Android Release"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - "capacitor/**"
+      - ".github/workflows/android-release.yml"
   release:
     types: [ published ]
   workflow_dispatch:
@@ -47,6 +52,11 @@ jobs:
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
             VERSION_NAME="${GITHUB_REF_NAME#v}"
             TRACKS="internal production"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # Automatisches Test-Release auf main: nur an die Test-User (Internal Testing)
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match='v*')
+            VERSION_NAME="${LATEST_TAG#v}-test${VERSION_CODE}"
+            TRACKS="internal"
           else
             if ! [[ "${ALPHA}" =~ ^[0-9]+$ ]]; then
               echo "Invalid alpha input: ${ALPHA}" >&2


### PR DESCRIPTION
## Zusammenfassung

Erweitert den bestehenden Android-Release-Workflow (`android-release.yml`) um ein **automatisches Test-Release auf `main`**. Pushes auf `main` bauen jetzt automatisch eine signierte AAB und verteilen sie an die Test-User über den Play **Internal Testing**-Track — denselben Kanal, den der manuelle `workflow_dispatch` heute schon als „nur Internal Testing" nutzt.

Der Trigger ist bewusst auf `capacitor/**` (+ den Workflow selbst) beschränkt: Die Android-App ist ein dünner Wrapper der gehosteten PWA (`webDir: 'empty'`, `server.url: https://einsatz.ffnd.at`). Frontend-Änderungen werden über den Web-Deploy ausgeliefert, daher rechtfertigen nur native Änderungen eine neue AAB.

## Änderungen

- Neuer `push`-Trigger auf `main`, gefiltert auf `capacitor/**` und `.github/workflows/android-release.yml`.
- Neuer Zweig in der Versions-/Track-Logik für `push`-Events:
  - `versionName` = `<letzter-Tag>-test<versionCode>` (z.B. `2.55.0-test1234`)
  - `versionCode` = `git rev-list --count HEAD` (auf `main` monoton steigend, eindeutig pro Commit)
  - Track: nur `internal` (Test-User), nicht `production`
- `release`- und `workflow_dispatch`-Verhalten bleiben unverändert.
- Die `concurrency`-Group serialisiert main-Builds bereits über `github.ref`.

## Test plan

- [ ] Push mit Änderung unter `capacitor/**` auf `main` → Workflow läuft, baut AAB, lädt sie in den `internal`-Track hoch
- [ ] Push ohne `capacitor/**`-Änderung (z.B. nur Doku) → Workflow läuft **nicht**
- [ ] `versionName` im Play-Console-Release trägt das `-test<versionCode>`-Suffix
- [ ] Manueller `workflow_dispatch` (alpha) und GitHub-Release funktionieren unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa4CbSjZjx5k6xex2LL3Fa)_