### PR TITLE
feat(area): Quadratmeter einer Fläche berechnen und anzeigen

### DIFF
--- a/src/components/FirecallItems/elements/FirecallArea.tsx
+++ b/src/components/FirecallItems/elements/FirecallArea.tsx
@@ -5,6 +5,8 @@ import { Area, FirecallItem } from '../../firebase/firestore';
 import { leafletIcons } from '../icons';
 import { FirecallItemBase } from './FirecallItemBase';
 import AreaMarker from './area/AreaComponent';
+import { calculateArea, formatArea } from './area/area';
+import { getConnectionPositions } from './connection/distance';
 import { MarkerRenderOptions } from './marker/FirecallItemDefault';
 
 export class FirecallArea extends FirecallItemBase {
@@ -16,6 +18,8 @@ export class FirecallArea extends FirecallItemBase {
   color?: string;
   opacity?: number;
   alwaysShowMarker?: string;
+  /** polygon area in square meters */
+  area?: number;
 
   public constructor(firecallItem?: Area) {
     super(firecallItem);
@@ -27,7 +31,20 @@ export class FirecallArea extends FirecallItemBase {
       color: this.color = 'blue',
       opacity: this.opacity = 50,
       alwaysShowMarker: this.alwaysShowMarker,
+      area: this.area,
     } = firecallItem || {});
+  }
+
+  /**
+   * Return the polygon area in square meters. Uses the persisted value when
+   * available and falls back to computing it from the positions (e.g. for
+   * areas drawn before the area was persisted).
+   */
+  public areaValue(): number {
+    if (typeof this.area === 'number') {
+      return this.area;
+    }
+    return calculateArea(getConnectionPositions(this.data()));
   }
 
   public copy(): FirecallArea {
@@ -44,6 +61,7 @@ export class FirecallArea extends FirecallItemBase {
       color: this.color,
       opacity: this.opacity,
       alwaysShowMarker: this.alwaysShowMarker,
+      area: this.area,
     } as Area;
   }
 
@@ -54,14 +72,17 @@ export class FirecallArea extends FirecallItemBase {
   // public title(): string {
   //   return `Marker ${this.name}`;
   // }
-  // public info(): string {
-  //   return `Länge ${this.distance}m`;
-  // }
+
+  public info(): string {
+    return `Fläche: ${formatArea(this.areaValue())}`;
+  }
 
   public body(): ReactNode {
     return (
       <>
         {super.body()}
+        Fläche: {formatArea(this.areaValue())}
+        <br />
         {this.lat},{this.lng} =&gt; {this.destLat},{this.destLng}
       </>
     );
@@ -102,6 +123,8 @@ export class FirecallArea extends FirecallItemBase {
     return (
       <>
         <b>Fläche {this.name}</b>
+        <br />
+        {formatArea(this.areaValue())}
       </>
     );
   }

--- a/src/components/FirecallItems/elements/FirecallArea.tsx
+++ b/src/components/FirecallItems/elements/FirecallArea.tsx
@@ -1,5 +1,5 @@
 import { Icon, IconOptions } from 'leaflet';
-import { ReactNode } from 'react';
+import { Fragment, ReactNode } from 'react';
 import { defaultPosition } from '../../../hooks/constants';
 import { Area, FirecallItem } from '../../firebase/firestore';
 import { leafletIcons } from '../icons';
@@ -124,6 +124,13 @@ export class FirecallArea extends FirecallItemBase {
       <>
         <b>Fläche {this.name}</b>
         <br />
+        {this.beschreibung &&
+          this.beschreibung.split('\n').map((s, index) => (
+            <Fragment key={`${index}-${s}`}>
+              {s}
+              <br />
+            </Fragment>
+          ))}
         {formatArea(this.areaValue())}
       </>
     );

--- a/src/components/FirecallItems/elements/area/area.test.ts
+++ b/src/components/FirecallItems/elements/area/area.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { LatLngPosition } from '../../../../common/geo';
+import { calculateArea, formatArea } from './area';
+
+describe('calculateArea', () => {
+  it('returns 0 for fewer than 3 positions', () => {
+    expect(calculateArea([])).toBe(0);
+    expect(calculateArea([[47, 16]])).toBe(0);
+    expect(
+      calculateArea([
+        [47, 16],
+        [47.001, 16],
+      ])
+    ).toBe(0);
+  });
+
+  it('computes the area of a small rectangle near Neusiedl (~8450 m²)', () => {
+    // ~0.001° latitude  ≈ 111.32 m
+    // ~0.001° longitude ≈ 75.9 m at 47° N
+    // → expected area ≈ 8450 m²
+    const rectangle: LatLngPosition[] = [
+      [47.0, 16.0],
+      [47.001, 16.0],
+      [47.001, 16.001],
+      [47.0, 16.001],
+    ];
+    const area = calculateArea(rectangle);
+    expect(area).toBeGreaterThan(8200);
+    expect(area).toBeLessThan(8700);
+  });
+
+  it('is independent of winding order (returns absolute area)', () => {
+    const clockwise: LatLngPosition[] = [
+      [47.0, 16.0],
+      [47.001, 16.0],
+      [47.001, 16.001],
+      [47.0, 16.001],
+    ];
+    const counterClockwise: LatLngPosition[] = [...clockwise].reverse();
+    expect(calculateArea(counterClockwise)).toBeCloseTo(
+      calculateArea(clockwise),
+      5
+    );
+  });
+
+  it('ignores an explicitly closed ring (first === last point)', () => {
+    const open: LatLngPosition[] = [
+      [47.0, 16.0],
+      [47.001, 16.0],
+      [47.001, 16.001],
+      [47.0, 16.001],
+    ];
+    const closed: LatLngPosition[] = [...open, [47.0, 16.0]];
+    expect(calculateArea(closed)).toBeCloseTo(calculateArea(open), 3);
+  });
+});
+
+describe('formatArea', () => {
+  it('shows small areas in square meters (rounded, no decimals)', () => {
+    expect(formatArea(0)).toBe('0 m²');
+    expect(formatArea(8450.3)).toBe('8450 m²');
+    expect(formatArea(9999)).toBe('9999 m²');
+  });
+
+  it('shows areas of 1 hectare or more in hectares', () => {
+    expect(formatArea(10000)).toBe('1 ha');
+    expect(formatArea(12345)).toBe('1.23 ha');
+    expect(formatArea(255000)).toBe('25.5 ha');
+  });
+
+  it('shows areas of 1 km² or more in square kilometers', () => {
+    expect(formatArea(1_000_000)).toBe('1 km²');
+    expect(formatArea(1_500_000)).toBe('1.5 km²');
+  });
+});

--- a/src/components/FirecallItems/elements/area/area.ts
+++ b/src/components/FirecallItems/elements/area/area.ts
@@ -1,0 +1,52 @@
+import { LatLngPosition } from '../../../../common/geo';
+
+/** WGS84 equatorial earth radius in meters (same value @turf/area uses). */
+const EARTH_RADIUS = 6378137;
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+
+/**
+ * Calculate the geodesic area of a polygon described by lat/lng positions.
+ *
+ * Uses the spherical ring-area formula (identical approach to @turf/area /
+ * OpenLayers `getArea`). The ring is treated as implicitly closed, so the
+ * first and last point do not need to be equal. Winding order does not
+ * matter — the absolute area is returned.
+ *
+ * @param positions polygon vertices as `[lat, lng]` pairs
+ * @returns area in square meters (0 for fewer than 3 vertices)
+ */
+export const calculateArea = (positions: LatLngPosition[]): number => {
+  if (!positions || positions.length < 3) {
+    return 0;
+  }
+
+  let total = 0;
+  const len = positions.length;
+  for (let i = 0; i < len; i++) {
+    const [lat1, lng1] = positions[i];
+    const [lat2, lng2] = positions[(i + 1) % len];
+    total +=
+      toRad(lng2 - lng1) * (2 + Math.sin(toRad(lat1)) + Math.sin(toRad(lat2)));
+  }
+  total = (total * EARTH_RADIUS * EARTH_RADIUS) / 2;
+  return Math.abs(total);
+};
+
+/** Round to at most `digits` decimals and drop trailing zeros. */
+const round = (value: number, digits: number): number =>
+  Number(value.toFixed(digits));
+
+/**
+ * Format an area (in square meters) into a human readable string, switching to
+ * larger units for bigger areas: m² (< 1 ha), ha (< 1 km²), km² (≥ 1 km²).
+ */
+export const formatArea = (area: number): string => {
+  if (area >= 1_000_000) {
+    return `${round(area / 1_000_000, 2)} km²`;
+  }
+  if (area >= 10_000) {
+    return `${round(area / 10_000, 2)} ha`;
+  }
+  return `${Math.round(area)} m²`;
+};

--- a/src/components/FirecallItems/elements/connection/positions.ts
+++ b/src/components/FirecallItems/elements/connection/positions.ts
@@ -11,6 +11,7 @@ import {
   MultiPointItem,
 } from '../../../firebase/firestore';
 import { logAuditChange } from '../../../../hooks/useAuditLog';
+import { calculateArea } from '../area/area';
 import { calculateDistance, getConnectionPositions } from './distance';
 
 export async function updateFirecallPositions(
@@ -86,6 +87,9 @@ const updateConnectionInFirestore = async (
     const newValue = {
       positions: JSON.stringify(positions),
       distance: Math.round(calculateDistance(positions)),
+      ...(fcItem.type === 'area'
+        ? { area: Math.round(calculateArea(positions)) }
+        : {}),
     };
     await setDoc(
       doc(

--- a/src/components/Map/Leitungen/context.tsx
+++ b/src/components/Map/Leitungen/context.tsx
@@ -5,17 +5,20 @@ import { useFirecallId } from '../../../hooks/useFirecall';
 import { addDoc } from '../../../lib/firestoreClient';
 import { firestore } from '../../firebase/firebase';
 import {
-  Connection,
   FIRECALL_COLLECTION_ID,
   FIRECALL_ITEMS_COLLECTION_ID,
+  MultiPointItem,
 } from '../../firebase/firestore';
 import { calculateDistance } from '../../FirecallItems/elements/connection/distance';
+import { calculateArea } from '../../FirecallItems/elements/area/area';
 
 interface Leitungen {
   isDrawing: boolean;
   setIsDrawing: React.Dispatch<React.SetStateAction<boolean>>;
-  firecallItem?: Connection;
-  setFirecallItem: React.Dispatch<React.SetStateAction<Connection | undefined>>;
+  firecallItem?: MultiPointItem;
+  setFirecallItem: React.Dispatch<
+    React.SetStateAction<MultiPointItem | undefined>
+  >;
   complete: (positions: L.LatLng[]) => void;
 }
 
@@ -29,13 +32,16 @@ export interface LeitungsProviderProps {
 
 export const useLeitungsProvider = (): Leitungen => {
   const [isDrawing, setIsDrawing] = useState(false);
-  const [firecallItem, setFirecallItem] = useState<Connection>();
+  const [firecallItem, setFirecallItem] = useState<MultiPointItem>();
   const firecallId = useFirecallId();
   const { email } = useFirebaseLogin();
 
   const complete = useCallback(
     (positions: L.LatLng[]) => {
       if (firecallItem) {
+        const latLngPositions = positions.map(
+          (p) => [p.lat, p.lng] as [number, number]
+        );
         addDoc(
           collection(
             firestore,
@@ -49,10 +55,11 @@ export const useLeitungsProvider = (): Leitungen => {
             lng: positions[0].lng,
             user: email,
             created: new Date().toISOString(),
-            positions: JSON.stringify(positions.map((p) => [p.lat, p.lng])),
-            distance: Math.round(
-              calculateDistance(positions.map((p) => [p.lat, p.lng]))
-            ),
+            positions: JSON.stringify(latLngPositions),
+            distance: Math.round(calculateDistance(latLngPositions)),
+            ...(firecallItem.type === 'area'
+              ? { area: Math.round(calculateArea(latLngPositions)) }
+              : {}),
             destLat: positions[positions.length - 1].lat,
             destLng: positions[positions.length - 1].lng,
           }

--- a/src/components/firebase/firestore.ts
+++ b/src/components/firebase/firestore.ts
@@ -259,6 +259,8 @@ export interface Area extends MultiPointItem {
   type: 'area';
   opacity?: number;
   alwaysShowMarker?: string;
+  /** polygon area in square meters (persisted, derived from positions) */
+  area?: number;
 }
 
 export interface Line extends MultiPointItem {


### PR DESCRIPTION
## Zusammenfassung

Flächen-Items (`area`) zeigen jetzt ihre Größe in Quadratmetern an. Die Fläche wird beim Zeichnen sowie bei jeder Punkt-Änderung berechnet und als neues Feld `area` in Firestore **persistiert**, sodass nicht jeder Client den Wert ständig neu berechnen muss. Für bestehende Flächen ohne persistierten Wert wird die Fläche als Fallback live aus den Positionen berechnet.

## Änderungen

- Neue, getestete Hilfsfunktionen in `area.ts`:
  - `calculateArea(positions)` — geodätische Fläche (sphärische Ring-Formel, WGS84, identischer Ansatz wie `@turf/area`), unabhängig von der Wicklungsrichtung, ohne neue Dependency.
  - `formatArea(area)` — Formatierung mit automatischer Einheitenwahl (m² / ha / km²).
- `Area`-Typ um optionales Feld `area` (m²) erweitert.
- `FirecallArea`: Feld `area`, `areaValue()` (persistierter Wert mit Live-Fallback), Anzeige der Fläche in Popup, Body und Info-Zeile.
- Persistierung der Fläche beim Zeichnen (`Leitungen/context.tsx`) und beim Verschieben/Hinzufügen/Löschen von Punkten (`connection/positions.ts`) — nur für Items vom Typ `area`.
- Context-Typ von `Connection` auf `MultiPointItem` verbreitert (Flächen werden über denselben Zeichen-Flow erstellt).

## Test plan

- [x] `calculateArea`/`formatArea` per TDD getestet (7 Tests, u.a. Rechteck ~8450 m², Wicklungsrichtung, geschlossener Ring, Einheiten-Umschaltung)
- [x] `npx tsc --noEmit` fehlerfrei
- [x] `npx eslint` fehlerfrei
- [x] `npx vitest run` — 1225 Tests grün
- [x] `npx next build --webpack` erfolgreich
- [ ] Manuell: Fläche zeichnen → m² im Popup sichtbar
- [ ] Manuell: Punkt verschieben → m² aktualisiert sich
- [ ] Manuell: bestehende Fläche (ohne `area`) zeigt berechneten Wert

🤖 Generated with [Claude Code](https://claude.com/claude-code)