### PR TITLE
fix(android): Foreground-Service über Notification beendbar machen

### DIFF
--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt
@@ -74,6 +74,10 @@ class RadiacodeForegroundService : Service() {
         const val ACTION_UPDATE = "at.ffnd.einsatzkarte.RADIACODE_UPDATE"
         const val ACTION_STOP = "at.ffnd.einsatzkarte.RADIACODE_STOP"
         const val ACTION_DISCONNECT_REQUESTED = "at.ffnd.einsatzkarte.RADIACODE_DISCONNECT_REQUESTED"
+        // User hat die „Beenden"-Action der Notification getippt. Beendet ALLE
+        // aktuell aktiven Hintergrund-Modi (Radiacode/GPS-Track/Live-Share) über
+        // die JS-Owner — der Service stoppt sich nach dem letzten Modus selbst.
+        const val ACTION_STOP_REQUESTED = "at.ffnd.einsatzkarte.RADIACODE_STOP_REQUESTED"
         const val ACTION_BLE_CONNECT = "at.ffnd.einsatzkarte.RADIACODE_BLE_CONNECT"
         const val ACTION_BLE_DISCONNECT = "at.ffnd.einsatzkarte.RADIACODE_BLE_DISCONNECT"
         const val ACTION_START_TRACK = "at.ffnd.einsatzkarte.RADIACODE_START_TRACK"
@@ -292,7 +296,9 @@ class RadiacodeForegroundService : Service() {
         if (action == ACTION_BLE_CONNECT) {
             bleSessionActive = true
         }
-        if (action != null && action != ACTION_STOP && action != ACTION_DISCONNECT_REQUESTED) {
+        if (action != null && action != ACTION_STOP &&
+            action != ACTION_DISCONNECT_REQUESTED && action != ACTION_STOP_REQUESTED
+        ) {
             ensureForeground()
         }
 
@@ -322,6 +328,14 @@ class RadiacodeForegroundService : Service() {
             }
             ACTION_DISCONNECT_REQUESTED -> {
                 RadiacodeNotificationPlugin.onDisconnectRequested()
+            }
+            ACTION_STOP_REQUESTED -> {
+                // Generische „Beenden"-Action: JS-Owner beenden jeden aktiven
+                // Modus über ihren regulären Stop-Pfad (hält den React-Status
+                // konsistent). Der Service stoppt sich nach dem letzten Modus
+                // selbst — kein nativer Teardown hier, um die ACTION_STOP-Races
+                // (siehe oben) nicht zu reaktivieren.
+                RadiacodeNotificationPlugin.onStopRequested()
             }
             ACTION_BLE_CONNECT -> {
                 val address = intent?.getStringExtra(EXTRA_DEVICE_ADDRESS)
@@ -1037,6 +1051,14 @@ class RadiacodeForegroundService : Service() {
             else -> "Radiacode getrennt"
         }
         lastTitle = title
+        // Bei reinen GPS-/Live-Share-Modi (kein Radiacode) trägt der Body keinen
+        // Messwert — stattdessen ein klarer Hinweis, dass die Funktion im
+        // Hintergrund weiterläuft und über die Notification beendet werden kann
+        // (Play-FGS-Wahrnehmbarkeit). Bei aktivem Radiacode bleibt der
+        // Live-Messwert-Body erhalten.
+        if (radiaCode == null && (track || liveShare)) {
+            lastBody = getString(R.string.radiacode_notification_background_hint)
+        }
         ensureForeground()
     }
 
@@ -1062,11 +1084,16 @@ class RadiacodeForegroundService : Service() {
             this, 0, tapIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        val disconnectIntent = Intent(this, RadiacodeForegroundService::class.java).apply {
-            action = ACTION_DISCONNECT_REQUESTED
+        val stop = resolveStopAction()
+        val stopIntent = Intent(this, RadiacodeForegroundService::class.java).apply {
+            action = stop.action
         }
-        val disconnectPending = PendingIntent.getService(
-            this, 1, disconnectIntent,
+        // request code je Action, damit der CONNECTED_DEVICE-Pfad
+        // (ACTION_DISCONNECT_REQUESTED) und der generische Stop-Pfad
+        // (ACTION_STOP_REQUESTED) sich nicht denselben PendingIntent teilen.
+        val stopRequestCode = if (stop.action == ACTION_DISCONNECT_REQUESTED) 1 else 2
+        val stopPending = PendingIntent.getService(
+            this, stopRequestCode, stopIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
         return NotificationCompat.Builder(this, CHANNEL_ID)
@@ -1076,14 +1103,48 @@ class RadiacodeForegroundService : Service() {
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setContentIntent(tapPending)
-            .addAction(
-                0,
-                getString(R.string.radiacode_notification_action_disconnect),
-                disconnectPending,
-            )
+            .addAction(0, getString(stop.labelRes), stopPending)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .build()
+    }
+
+    private data class StopAction(val labelRes: Int, val action: String)
+
+    /**
+     * Wählt Label und Intent-Action der Notification-„Beenden"-Action passend
+     * zu den aktuell laufenden Modi:
+     * - Radiacode aktiv (ggf. + weitere) → „Trennen" (trennt die BLE-Session
+     *   über den bestehenden disconnectRequested-Pfad).
+     * - sonst nur Live-Share → „Teilen beenden".
+     * - sonst nur GPS-/Track-Aufzeichnung → „Aufzeichnung beenden".
+     * - sonst mehrere Nicht-Radiacode-Modi → „Im Hintergrund beenden".
+     */
+    private fun resolveStopAction(): StopAction {
+        val track = gpsTrackRecorder != null || trackRecorder != null
+        val liveShare = liveLocationPusher != null
+        return when {
+            radiaCode != null -> StopAction(
+                R.string.radiacode_notification_action_disconnect,
+                ACTION_DISCONNECT_REQUESTED,
+            )
+            track && liveShare -> StopAction(
+                R.string.radiacode_notification_action_stop_background,
+                ACTION_STOP_REQUESTED,
+            )
+            liveShare -> StopAction(
+                R.string.radiacode_notification_action_stop_share,
+                ACTION_STOP_REQUESTED,
+            )
+            track -> StopAction(
+                R.string.radiacode_notification_action_stop_track,
+                ACTION_STOP_REQUESTED,
+            )
+            else -> StopAction(
+                R.string.radiacode_notification_action_disconnect,
+                ACTION_DISCONNECT_REQUESTED,
+            )
+        }
     }
 
     private fun ensureChannel() {

--- a/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeNotificationPlugin.java
+++ b/capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeNotificationPlugin.java
@@ -304,6 +304,14 @@ public class RadiacodeNotificationPlugin extends Plugin {
         }
     }
 
+    static void onStopRequested() {
+        RadiacodeNotificationPlugin i = instance;
+        Log.i(TAG, "onStopRequested hasInstance=" + (i != null));
+        if (i != null) {
+            i.notifyListeners("stopRequested", new JSObject());
+        }
+    }
+
     public static void emitMeasurement(Measurement m) {
         RadiacodeNotificationPlugin i = instance;
         if (i == null) return;

--- a/capacitor/android/app/src/main/res/values/strings.xml
+++ b/capacitor/android/app/src/main/res/values/strings.xml
@@ -20,7 +20,11 @@
     <string name="offline_overlay_title">Keine Verbindung</string>
     <string name="offline_overlay_message">Einsatzkarte wartet auf Netzwerk…</string>
     <string name="offline_overlay_retry">Jetzt erneut versuchen</string>
-    <string name="radiacode_notification_channel_name">Radiacode Verbindung</string>
-    <string name="radiacode_notification_channel_desc">Zeigt Live-Messwerte während einer Radiacode-Verbindung.</string>
+    <string name="radiacode_notification_channel_name">Hintergrunddienst</string>
+    <string name="radiacode_notification_channel_desc">Hinweis, während Radiacode-Verbindung, GPS-Aufzeichnung oder Live-Standort im Hintergrund laufen.</string>
     <string name="radiacode_notification_action_disconnect">Trennen</string>
+    <string name="radiacode_notification_action_stop_track">Aufzeichnung beenden</string>
+    <string name="radiacode_notification_action_stop_share">Teilen beenden</string>
+    <string name="radiacode_notification_action_stop_background">Im Hintergrund beenden</string>
+    <string name="radiacode_notification_background_hint">Läuft im Hintergrund · zum Beenden tippen</string>
 </resources>

--- a/docs/superpowers/specs/2026-06-30-android-fgs-notification-control-design.md
+++ b/docs/superpowers/specs/2026-06-30-android-fgs-notification-control-design.md
@@ -1,0 +1,148 @@
+# Android Foreground-Service: wahrnehmbar & über die Notification beendbar
+
+**Datum:** 2026-06-30
+**Status:** Design (genehmigt, Ansatz A)
+**Plattform:** Android (Capacitor) — `RadiacodeForegroundService`
+
+## Problem
+
+Google Play hat die App abgelehnt (Foreground-Service-Policy):
+
+> Wir haben festgestellt, dass mindestens einer der erklärten Anwendungsfälle nicht
+> den Vorgaben zur Verwendung der Berechtigung für Dienste im Vordergrund entspricht.
+> Der Nutzer wird insbesondere nicht auf eine Funktion hingewiesen, die eine
+> Berechtigung erfordert, wenn sie aktiv ist. Beim Ausführen der Funktion für den
+> Connected Device – Connected Device Other ist die Verwendung eines Diensts im
+> Vordergrund für den Nutzer nicht wahrnehmbar.
+
+Ziele:
+
+1. Der Hintergrunddienst muss **wahrnehmbar** sein (klar erkennbar, dass eine Funktion
+   im Hintergrund läuft, die die Berechtigung benötigt).
+2. Der User muss den Dienst **wieder deaktivieren** können.
+3. Der Dienst soll **nur laufen, wenn er benötigt wird**.
+
+## Ausgangslage (Code-Stand)
+
+Der `RadiacodeForegroundService` trägt mehrere Modi gleichzeitig:
+
+- **Radiacode-BLE** (`connectedDevice`-FGS-Typ, seit Commit `4bd40d99` nur bei aktiver
+  BLE-Session) — Owner in JS: [`RadiacodeProvider`](../../../src/components/providers/RadiacodeProvider.tsx)
+- **GPS-Track-Aufzeichnung** (`location`) — Owner: [`useGpsLineRecorder`](../../../src/hooks/recording/useGpsLineRecorder.ts)
+- **Live-Standort teilen** (`location`) — Owner: Live-Share-Hook über
+  [`nativeGpsTrackBridge`](../../../src/hooks/recording/nativeGpsTrackBridge.ts)
+
+Jeder Modus hat im Service einen eigenen, sauberen Teardown-Pfad
+(`ACTION_BLE_DISCONNECT`, `ACTION_STOP_GPS_TRACK`, `ACTION_STOP_LIVE_SHARE`), der den
+Service beendet (`stopForeground` + `stopSelf`), sobald der **letzte** Modus weg ist
+(siehe [`RadiacodeForegroundService.kt:335-345, 414-426, 470-490`](../../../capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt)).
+
+**Gaps:**
+
+- Die FGS-Notification hat genau **eine** Action, fest verdrahtet als „Trennen"
+  → Event `disconnectRequested` → im JS nur an den Radiacode-Disconnect gehängt
+  ([`bleAdapter.capacitor.ts:229`](../../../src/hooks/radiacode/bleAdapter.capacitor.ts#L229),
+  [`buildNotification()` in RadiacodeForegroundService.kt:1057-1087`](../../../capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt#L1057)).
+- Bei einer **reinen GPS-Track-/Live-Share-Session ohne Radiacode** steht trotzdem
+  „Trennen" in der Notification und der Button bewirkt **nichts** — diese Modi sind aus
+  der Notification nicht beendbar.
+- Notification-Body/Channel-Text sind Radiacode-zentriert und machen nicht klar, dass
+  die Funktion im Hintergrund weiterläuft.
+
+## Gewählter Ansatz: A — eine modus-bewusste „Beenden"-Action
+
+Eine einzelne Notification-Action, deren **Label und Wirkung** sich an die aktuell
+laufenden Modi anpassen. Sie feuert ein generisches `stopRequested`-Event an JS; die
+jeweiligen Owner beenden ihren Modus über den bestehenden Stop-Pfad. Der Service beendet
+sich nach dem letzten Modus selbst.
+
+**Verworfene Alternativen:**
+
+- **Ansatz B (mehrere Actions, eine pro Modus):** Notifications zeigen max. 3 Actions,
+  schnell unübersichtlich; mehr Code/Events; für die Play-Store-Wahrnehmbarkeit kein
+  Mehrwert.
+- **Bestätigungsdialog beim Start** / **Settings-Schalter:** bewusst nicht gewählt
+  (Scope-Entscheidung des Auftraggebers — „Notification verbessern").
+
+Die Feinsteuerung „nur Live-Share stoppen, Radiacode behalten" bleibt **in der App**
+erhalten; aus der Notification wird bewusst „alles im Hintergrund beenden" angeboten.
+
+## Designkomponenten
+
+### 1. Notification-Text (Wahrnehmbarkeit)
+
+- `updateNotificationForState()` setzt weiterhin den modus-spezifischen **Titel**.
+- Der **Body** bekommt für jeden Modus einen klaren Zusatz, dass die Funktion im
+  Hintergrund weiterläuft und über die Notification beendet werden kann
+  (z. B. Suffix „· Läuft im Hintergrund").
+- Die **Channel-Beschreibung** wird allgemeiner gefasst (nicht nur „Radiacode-Verbindung",
+  da der Channel auch GPS-Track und Live-Share trägt).
+
+### 2. Modus-bewusste Action (`buildNotification`)
+
+Action-Label dynamisch nach aktiven Modi:
+
+| Aktive Modi                     | Label                   |
+|---------------------------------|-------------------------|
+| Radiacode (ggf. + weitere)      | `Trennen`               |
+| nur GPS-Track                   | `Aufzeichnung beenden`  |
+| nur Live-Share                  | `Teilen beenden`        |
+| mehrere Nicht-Radiacode-Modi    | `Im Hintergrund beenden`|
+
+`buildNotification(title, body)` erhält dazu Zugriff auf den aktuellen Modus-Status
+(über die bestehenden Felder `radiaCode`, `gpsTrackRecorder`, `trackRecorder`,
+`liveLocationPusher`). Die Action feuert eine neue Service-Action
+`ACTION_STOP_REQUESTED`.
+
+### 3. Stop-Routing
+
+- Neue Service-Action `ACTION_STOP_REQUESTED` →
+  `RadiacodeNotificationPlugin` emittiert ein neues JS-Event `stopRequested`.
+- Ein **zentraler JS-Listener** auf `stopRequested` beendet **alle** aktuell aktiven
+  Hintergrund-Modi über die bestehenden Owner/Bridges:
+  - Radiacode: `nativeDisconnect()`
+  - GPS-Track: `stopGpsTrack()`
+  - Live-Share: `stopLiveShare()`
+- Jeder Aufruf nutzt den vorhandenen Native-Stop-Pfad; der Service beendet sich nach
+  dem letzten Modus selbst (keine zusätzliche native Teardown-Logik, damit die in
+  [`RadiacodeForegroundService.kt:306-321`](../../../capacitor/android/app/src/main/java/at/ffnd/einsatzkarte/RadiacodeForegroundService.kt#L306)
+  dokumentierten Teardown-Races nicht reaktiviert werden).
+- `disconnectRequested` (Radiacode-only) bleibt für Abwärtskompatibilität bestehen.
+
+**Ownership-Hinweis:** Das Stoppen läuft bewusst über JS (wie schon heute bei
+`disconnectRequested`), damit der React-State (Verbindungs-/Aufzeichnungs-Status in der
+UI) konsistent bleibt. Der FGS hält den Prozess am Leben, der Capacitor-Bridge-Pfad ist
+also auch bei gesperrtem Screen verfügbar.
+
+### 4. Strings / i18n
+
+- Die FGS-Notification ist **nativ** (nicht über next-intl) → neue Labels/Body-Texte in
+  [`strings.xml`](../../../capacitor/android/app/src/main/res/values/strings.xml).
+- Bestehender Key `radiacode_notification_action_disconnect` bleibt; neue Keys für die
+  weiteren Action-Labels (`..._action_stop_track`, `..._action_stop_share`,
+  `..._action_stop_background`) und optional einen Body-Suffix.
+
+## Nicht im Scope
+
+- Kein neuer Settings-Schalter „Hintergrundbetrieb erlauben".
+- Kein Bestätigungsdialog beim Start einer hintergrundfähigen Funktion.
+- Keine Änderung an der `connectedDevice`-/`location`-Typ-Logik (bereits durch
+  `4bd40d99` adressiert).
+- Keine Anpassung der Play-Console-Use-Case-Deklaration (separater, nicht-Code-Schritt;
+  ggf. als Hinweis im PR vermerken).
+
+## Testplan
+
+- **Unit/JS:** `stopRequested`-Listener beendet bei verschiedenen Modus-Kombinationen die
+  jeweils aktiven Modi (Radiacode / GPS / Live / Kombinationen). Tests mit Vitest, neben
+  der Quelldatei (`*.test.ts`).
+- **Manuell (Gerät):**
+  1. Nur GPS-Track starten → Notification zeigt „Aufzeichnung beenden"; Tippen beendet
+     Track + Service.
+  2. Nur Live-Share starten → „Teilen beenden" beendet Live-Share + Service.
+  3. GPS-Track + Live-Share → „Im Hintergrund beenden" beendet beide + Service.
+  4. Radiacode verbunden (+ ggf. Track) → „Trennen" trennt Radiacode (bestehender Pfad
+     unverändert).
+  5. Screen gesperrt / App im Hintergrund: Notification-Action funktioniert weiterhin.
+- **Build:** `npx tsc --noEmit`, `npx eslint`, `npx vitest run`, `npx next build --webpack`;
+  Android-Build mit JDK 21 (`./gradlew :app:assembleDebug`).

--- a/src/components/providers/GpsProvider.tsx
+++ b/src/components/providers/GpsProvider.tsx
@@ -25,6 +25,7 @@ import {
   NativeGpsTrackOpts,
 } from '../../hooks/recording/nativeGpsTrackBridge';
 import { RadiacodeNotification } from '../../hooks/radiacode/radiacodeNotification';
+import { useNotificationStopListener } from '../../hooks/radiacode/useNotificationStopListener';
 import { SampleRateSpec } from '../../hooks/radiacode/types';
 import { RadiacodeDeviceRef } from '../../hooks/radiacode/types';
 import { useRadiacode } from './RadiacodeProvider';
@@ -175,6 +176,16 @@ const startGpsRecording = useCallback(async (lId: string, rate: SampleRateSpec) 
       await nativeStopGpsTrack().catch(() => null);
     }
   }, [gpsRecorder, isPositionSet, mode, position]);
+
+  // „Beenden"-Action der FGS-Notification: stoppt eine laufende
+  // GPS-/Radiacode-Aufzeichnung über den regulären stopRecording()-Pfad.
+  useNotificationStopListener(() => {
+    if (mode !== null || isRadiacodeTracking || isGpsTracking) {
+      stopRecording().catch((err) =>
+        console.warn('[GpsProvider] stopRecording after stopRequested failed', err),
+      );
+    }
+  });
 
   const value = useMemo(() => ({
     isRecording,

--- a/src/components/providers/LiveLocationProvider.tsx
+++ b/src/components/providers/LiveLocationProvider.tsx
@@ -17,6 +17,7 @@ import {
 import useFirebaseLogin from '../../hooks/useFirebaseLogin';
 import { useFirecall, useFirecallId } from '../../hooks/useFirecall';
 import { useLiveLocationShare } from '../../hooks/useLiveLocationShare';
+import { useNotificationStopListener } from '../../hooks/radiacode/useNotificationStopListener';
 import {
   LiveLocationSettings,
   useLiveLocationSettings,
@@ -175,6 +176,14 @@ export function LiveLocationProvider({ children }: { children: React.ReactNode }
       void start();
     });
   }, [uid, firecallId, start]);
+
+  // „Beenden"-Action der FGS-Notification: beendet das Live-Standort-Teilen
+  // über den regulären stop()-Pfad (hält den React-Status synchron).
+  useNotificationStopListener(() => {
+    if (isSharing) {
+      void stop();
+    }
+  });
 
   const canShare = isPositionSet && !!uid && firecallId !== 'unknown';
 

--- a/src/components/providers/RadiacodeProvider.tsx
+++ b/src/components/providers/RadiacodeProvider.tsx
@@ -17,6 +17,7 @@ import {
   getBleAdapter,
 } from '../../hooks/radiacode/bleAdapter';
 import { RadiacodeClient } from '../../hooks/radiacode/client';
+import { useNotificationStopListener } from '../../hooks/radiacode/useNotificationStopListener';
 import {
   loadDefaultDevice,
   saveDefaultDevice,
@@ -573,6 +574,14 @@ export function RadiacodeProvider({
     });
     return () => unsub();
   }, [adapter, disconnect]);
+
+  // „Beenden"-Action der FGS-Notification: trennt die Radiacode-Verbindung
+  // über den regulären disconnect()-Pfad (hält den React-Status synchron).
+  useNotificationStopListener(() => {
+    disconnect().catch((err) => {
+      console.warn('[RadiacodeProvider] disconnect after stopRequested failed', err);
+    });
+  });
 
   const value = useMemo<RadiacodeContextValue>(
     () => ({

--- a/src/hooks/radiacode/radiacodeNotification.ts
+++ b/src/hooks/radiacode/radiacodeNotification.ts
@@ -86,6 +86,10 @@ export interface RadiacodeNotificationPlugin {
     listener: () => void,
   ): Promise<PluginListenerHandle>;
   addListener(
+    event: 'stopRequested',
+    listener: () => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
     event: 'measurement',
     listener: (data: NativeMeasurementEvent) => void,
   ): Promise<PluginListenerHandle>;

--- a/src/hooks/radiacode/useNotificationStopListener.test.ts
+++ b/src/hooks/radiacode/useNotificationStopListener.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const remove = vi.fn().mockResolvedValue(undefined);
+const mockAddListener = vi.fn();
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => 'android',
+  },
+  registerPlugin: () => ({
+    addListener: mockAddListener,
+  }),
+}));
+
+/** Fires the most recently registered `stopRequested` listener. */
+function fireStopRequested() {
+  const call = mockAddListener.mock.calls.at(-1);
+  const handler = call?.[1] as (() => void) | undefined;
+  handler?.();
+}
+
+describe('useNotificationStopListener', () => {
+  beforeEach(() => {
+    remove.mockClear();
+    mockAddListener.mockReset();
+    mockAddListener.mockResolvedValue({ remove });
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('subscribes to the native stopRequested event on mount', async () => {
+    const { useNotificationStopListener } = await import(
+      './useNotificationStopListener'
+    );
+    renderHook(() => useNotificationStopListener(vi.fn()));
+    await Promise.resolve();
+
+    expect(mockAddListener).toHaveBeenCalledWith(
+      'stopRequested',
+      expect.any(Function),
+    );
+  });
+
+  it('invokes the handler when the native event fires', async () => {
+    const { useNotificationStopListener } = await import(
+      './useNotificationStopListener'
+    );
+    const onStop = vi.fn();
+    renderHook(() => useNotificationStopListener(onStop));
+    await Promise.resolve();
+
+    fireStopRequested();
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes the latest handler without resubscribing on rerender', async () => {
+    const { useNotificationStopListener } = await import(
+      './useNotificationStopListener'
+    );
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ cb }) => useNotificationStopListener(cb),
+      { initialProps: { cb: first } },
+    );
+    await Promise.resolve();
+
+    rerender({ cb: second });
+    fireStopRequested();
+
+    expect(mockAddListener).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', async () => {
+    const { useNotificationStopListener } = await import(
+      './useNotificationStopListener'
+    );
+    const { unmount } = renderHook(() =>
+      useNotificationStopListener(vi.fn()),
+    );
+    await Promise.resolve();
+
+    unmount();
+    await Promise.resolve();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/radiacode/useNotificationStopListener.ts
+++ b/src/hooks/radiacode/useNotificationStopListener.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { RadiacodeNotification } from './radiacodeNotification';
+
+/**
+ * Abonniert das native `stopRequested`-Event des Foreground-Service und ruft
+ * `onStop` auf, wenn der Nutzer die „Beenden"-Action der Notification antippt.
+ *
+ * Jeder Owner eines Hintergrund-Modus (Radiacode-BLE, GPS-Track, Live-Share)
+ * verwendet diesen Hook mit seiner eigenen Stop-Funktion. So beendet ein Tap
+ * auf die Notification jeden aktuell aktiven Modus über dessen bestehenden
+ * Teardown-Pfad — der Service beendet sich, sobald der letzte Modus weg ist.
+ *
+ * Der Handler wird in einem Ref gehalten, damit ein State-Wechsel im Owner
+ * kein Re-Subscribe auslöst, aber beim Event-Eintritt immer die aktuelle
+ * Stop-Funktion läuft.
+ */
+export function useNotificationStopListener(
+  onStop: () => void | Promise<void>,
+): void {
+  const handlerRef = useRef(onStop);
+  useEffect(() => {
+    handlerRef.current = onStop;
+  }, [onStop]);
+
+  useEffect(() => {
+    let handle: { remove: () => Promise<void> } | null = null;
+    let removed = false;
+
+    RadiacodeNotification.addListener('stopRequested', () => {
+      void handlerRef.current();
+    })
+      .then((h) => {
+        if (removed) {
+          h.remove().catch(() => {});
+          return;
+        }
+        handle = h;
+      })
+      .catch(() => {});
+
+    return () => {
+      removed = true;
+      handle?.remove().catch(() => {});
+    };
+  }, []);
+}

--- a/src/hooks/recording/useRadiacodePointRecorder.test.tsx
+++ b/src/hooks/recording/useRadiacodePointRecorder.test.tsx
@@ -84,7 +84,9 @@ vi.mock('../../hooks/radiacode/radiacodeNotification', () => ({
       radiacodeTracking: false,
       gpsTracking: false,
     }),
-    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+    addListener: vi
+      .fn()
+      .mockResolvedValue({ remove: vi.fn().mockResolvedValue(undefined) }),
   },
 }));
 


### PR DESCRIPTION
## Zusammenfassung

Behebt den Play-Store-Ablehnungsgrund zur Foreground-Service-Policy („Beim Ausführen der Funktion für den Connected Device … ist die Verwendung eines Diensts im Vordergrund für den Nutzer nicht wahrnehmbar"). Der Android-Hintergrunddienst wird **wahrnehmbar** und durch den Nutzer **abschaltbar** gemacht, und er läuft nur, solange ein Modus aktiv ist.

Design: `docs/superpowers/specs/2026-06-30-android-fgs-notification-control-design.md` (Ansatz A — Notification verbessern).

## Änderungen

- **Modus-bewusste „Beenden"-Action** in der FGS-Notification:
  - Radiacode aktiv → „Trennen" (bestehender `disconnectRequested`-Pfad, unverändert)
  - nur GPS-/Track-Aufzeichnung → „Aufzeichnung beenden"
  - nur Live-Share → „Teilen beenden"
  - mehrere Nicht-Radiacode-Modi → „Im Hintergrund beenden"
- **Neues generisches `stopRequested`-Event** (`ACTION_STOP_REQUESTED` + `RadiacodeNotificationPlugin.onStopRequested()`). Behebt den Bug, dass reine GPS-Track-/Live-Share-Sessions (ohne Radiacode) aus der Notification **gar nicht** beendbar waren — die alte „Trennen"-Action lief dort ins Leere.
- **Wahrnehmbarkeit:** Body-Hinweis „Läuft im Hintergrund · zum Beenden tippen" für reine GPS-/Live-Share-Modi; allgemeinere Channel-Beschreibung (nicht mehr nur „Radiacode").
- **JS-Verdrahtung:** Neuer Hook `useNotificationStopListener` (testgetrieben). `RadiacodeProvider`, `GpsProvider` und `LiveLocationProvider` beenden ihren Modus über ihren **bestehenden** Stop-Pfad — der React-Status bleibt konsistent, der Service stoppt sich nach dem letzten Modus selbst.
- Test-Mock in `useRadiacodePointRecorder.test.tsx` an den echten `PluginListenerHandle.remove(): Promise<void>`-Kontrakt angeglichen.

## Test plan

- [x] `tsc --noEmit`, `eslint`, `vitest` (1222 passed), `next build --webpack`
- [x] Android `compileDebugKotlin` + `compileDebugJavaWithJavac` (JDK 21) → BUILD SUCCESSFUL
- [ ] **Gerät:** nur GPS-Track → „Aufzeichnung beenden" stoppt Track + Service
- [ ] **Gerät:** nur Live-Share → „Teilen beenden" stoppt Live-Share + Service
- [ ] **Gerät:** GPS-Track + Live-Share → „Im Hintergrund beenden" stoppt beide + Service
- [ ] **Gerät:** Radiacode verbunden → „Trennen" trennt wie bisher
- [ ] **Gerät:** Screen gesperrt / App im Hintergrund → Notification-Action funktioniert

## Hinweis (kein Code)

Unabhängig vom Code sollte zusätzlich die Use-Case-Deklaration für „Connected Device" in der Play Console nachgeschärft werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
