### PR TITLE
fix(android): commit internal-track releases without failing auto-review attempt

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -191,29 +191,45 @@ jobs:
 
           echo "==> Committing edit"
           commit_resp=$(mktemp)
-          commit_code=$(curl -sS -o "${commit_resp}" -w "%{http_code}" \
-            -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-            "${API}/edits/${EDIT_ID}:commit")
-          if [[ "${commit_code}" =~ ^2[0-9]{2}$ ]]; then
-            echo "Edit committed (auto-submitted for review)"
-          elif [[ "${commit_code}" == "400" ]] && grep -q "changesNotSentForReview" "${commit_resp}"; then
-            echo "Auto-review unavailable for this edit, retrying with changesNotSentForReview=true"
-            cat "${commit_resp}" >&2
-            retry_code=$(curl -sS -o "${commit_resp}" -w "%{http_code}" \
+          commit_edit() {  # $1 = optional query string, e.g. "?changesNotSentForReview=true"
+            curl -sS -o "${commit_resp}" -w "%{http_code}" \
               -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-              "${API}/edits/${EDIT_ID}:commit?changesNotSentForReview=true")
-            if [[ ! "${retry_code}" =~ ^2[0-9]{2}$ ]]; then
-              echo "HTTP ${retry_code} from commit retry" >&2
+              "${API}/edits/${EDIT_ID}:commit${1:-}"
+          }
+
+          if [[ " ${TRACKS} " == *" production "* ]]; then
+            # Production changes can be auto-submitted for review; fall back to a
+            # plain commit if Play refuses to send them for review automatically.
+            commit_code=$(commit_edit)
+            if [[ "${commit_code}" =~ ^2[0-9]{2}$ ]]; then
+              echo "Edit committed (auto-submitted for review)"
+            elif [[ "${commit_code}" == "400" ]] && grep -q "changesNotSentForReview" "${commit_resp}"; then
+              echo "Auto-review unavailable for this edit, retrying with changesNotSentForReview=true"
+              commit_code=$(commit_edit "?changesNotSentForReview=true")
+              if [[ ! "${commit_code}" =~ ^2[0-9]{2}$ ]]; then
+                echo "HTTP ${commit_code} from commit retry" >&2
+                cat "${commit_resp}" >&2
+                rm -f "${commit_resp}"
+                exit 1
+              fi
+              echo "::warning::Edit committed without auto-review. Submit manually in the Play Console."
+            else
+              echo "HTTP ${commit_code} from commit" >&2
               cat "${commit_resp}" >&2
               rm -f "${commit_resp}"
               exit 1
             fi
-            echo "::warning::Edit committed without auto-review. Submit manually in the Play Console."
           else
-            echo "HTTP ${commit_code} from commit" >&2
-            cat "${commit_resp}" >&2
-            rm -f "${commit_resp}"
-            exit 1
+            # Internal-testing-only edits are never sent for review (releases go
+            # live immediately), so changesNotSentForReview=true is the only valid path.
+            commit_code=$(commit_edit "?changesNotSentForReview=true")
+            if [[ ! "${commit_code}" =~ ^2[0-9]{2}$ ]]; then
+              echo "HTTP ${commit_code} from commit" >&2
+              cat "${commit_resp}" >&2
+              rm -f "${commit_resp}"
+              exit 1
+            fi
+            echo "Edit committed (internal testing — no review required)"
           fi
           rm -f "${commit_resp}"
           echo "Done — versionName=${VERSION_NAME} versionCode=${UPLOADED_VC} tracks=${TRACKS}"


### PR DESCRIPTION
## Zusammenfassung

Beim automatischen Tester-Release (PR #596) erscheint im Pipeline-Log ein roter `400 INVALID_ARGUMENT`. Der Release ist dabei erfolgreich — der 400 ist ein erwarteter, bereits abgefangener Zwischenschritt, aber er ist irreführend und erzeugt zusätzlich eine unpassende „Submit manually"-Warnung.

Ursache: Ein Play-Store-Edit, das nur den **Internal-Testing-Track** betrifft, kann von der Google Play API niemals automatisch zur Prüfung eingereicht werden (interne Tests durchlaufen keinen Review). Der bisherige Ablauf committete trotzdem zuerst ohne `changesNotSentForReview`, kassierte den 400 und wiederholte den Commit erst dann mit `changesNotSentForReview=true`.

Der Commit ist jetzt track-abhängig:
- **Internal-only** → committet direkt mit `changesNotSentForReview=true` (kein 400, keine irreführende Warnung).
- **Production** → versucht weiterhin den Auto-Review-Commit und fällt nur bei Bedarf (`400` + `changesNotSentForReview`) zurück.

## Änderungen

- [android-release.yml](.github/workflows/android-release.yml): Commit-Logik im Step „Upload AAB to Play Store" track-abhängig gemacht; gemeinsamer `commit_edit()`-Helper eingeführt, doppelter curl-Aufruf entfernt.

## Test plan

- [ ] Push auf `main` → Tester-Release auf Internal-Track läuft grün **ohne** 400 im Log; Ausgabe „Edit committed (internal testing — no review required)".
- [ ] Release-Event mit Production-Track → Auto-Review-Commit wird versucht; bei Verweigerung Fallback mit `changesNotSentForReview=true` inkl. Warnung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)